### PR TITLE
Fix/foreground service permissions

### DIFF
--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -39,8 +39,13 @@
         </activity>
 
         <service
-            android:name=".services.measurement.ForegroundServiceWrapper"
+            android:name=".services.measurement.MicrophoneLocationForegroundServiceWrapper"
             android:foregroundServiceType="location|microphone"
+            android:exported="false" />
+
+        <service
+            android:name=".services.measurement.MicrophoneOnlyForegroundServiceWrapper"
+            android:foregroundServiceType="microphone"
             android:exported="false" />
     </application>
 

--- a/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/PlatformModule.kt
+++ b/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/PlatformModule.kt
@@ -56,9 +56,7 @@ val platformModule: Module = module {
      * wrapped into a foreground service.
      */
     single<MeasurementRecordingService> {
-        AndroidMeasurementRecordingService(
-            context = get()
-        )
+        AndroidMeasurementRecordingService()
     }
 
     factory<AudioPlayer> { (filePath: String) ->

--- a/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/permission/util/Extensions.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/permission/util/Extensions.android.kt
@@ -29,30 +29,6 @@ internal fun Context.openPage(
     }
 }
 
-internal fun Activity.checkPermissions(
-    permissions: List<String>,
-): PermissionState {
-    permissions.ifEmpty {
-        return PermissionState.GRANTED
-    } // no permissions needed
-    val status: List<Int> = permissions.map {
-        this.checkSelfPermission(it)
-    }
-    val isOneDenied: Boolean = permissions.all {
-        this.shouldShowRequestPermissionRationale(it)
-    }
-    val isAllGranted: Boolean = status.all {
-        it == PackageManager.PERMISSION_GRANTED
-    }
-    return if (isAllGranted) {
-        PermissionState.GRANTED
-    } else if (isOneDenied) {
-        PermissionState.DENIED
-    } else {
-        PermissionState.NOT_DETERMINED
-    }
-}
-
 internal fun Activity.checkPermissionState(
     permission: String,
 ): PermissionState {


### PR DESCRIPTION
# Description

Fixes a crash when trying to start a measurement recording while location services permission wasn't granted.

## Changes

The problem was that the measurement recording foreground service was registered with both microphone and location permissions required in the android manifest. To still keep location services an optional permission, I've added two variants of the foreground service that are registered with two different sets of permission in the manifest: `MicrophoneOnlyForegroundServiceWrapper` requires only microphone access, while `MicrophoneLocationForegroundServiceWrapper` requires both microphone and location. When starting the service, based on the current state of those permissions, the correct service will be started.

## Linked issues

- #146 

## Checklist

- [x] Code compiles correctly on all platforms
- [x] All pre-existing tests are passing
- [ ] If needed, new tests have been added
- [ ] Extended the README / documentation if necessary
- [x] Added code has been documented
