### PR TITLE
Add a help button that shows the map legend

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -127,6 +127,11 @@
     <string name="settings_map_measurements_count_description">Adjust the maximum number of measurements shown on the map at once (set this to 0 to show all measurements)</string>
 
 
+    <!-- Map -->
+    <string name="map_legend_title">Legend</string>
+    <string name="map_legend_description">The map shows recorded noise levels by steps of 5 decibels.</string>
+
+
     <!-- User acoustics knowledge -->
     <string name="acoustics_knowledge_beginner_title">Beginner</string>
     <string name="acoustics_knowledge_beginner_description">I know nothing or only a few things about noise</string>

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/map/MapLegendView.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/map/MapLegendView.kt
@@ -1,0 +1,76 @@
+package org.noiseplanet.noisecapture.ui.components.map
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import noisecapture.composeapp.generated.resources.Res
+import noisecapture.composeapp.generated.resources.cancel
+import noisecapture.composeapp.generated.resources.map_legend_description
+import noisecapture.composeapp.generated.resources.map_legend_title
+import org.jetbrains.compose.resources.stringResource
+import org.noiseplanet.noisecapture.ui.components.button.NCButton
+import org.noiseplanet.noisecapture.ui.components.button.NCButtonColors
+import org.noiseplanet.noisecapture.ui.components.button.NCButtonStyle
+import org.noiseplanet.noisecapture.ui.components.button.NCButtonViewModel
+import org.noiseplanet.noisecapture.ui.theme.NoiseLevelColorRamp
+
+
+@Composable
+fun MapLegendView(
+    onDismissRequest: () -> Unit,
+) {
+
+    // - Properties
+
+    val items: Map<String, Color> = NoiseLevelColorRamp.palette.mapKeys { entry ->
+        ">= ${entry.key.toInt()} dB"
+    }
+
+    val cancelButtonViewModel = NCButtonViewModel(
+        title = Res.string.cancel,
+        style = NCButtonStyle.TEXT,
+        colors = {
+            NCButtonColors.Defaults.text()
+        }
+    )
+
+
+    // - Layout
+
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        confirmButton = {
+            NCButton(onClick = onDismissRequest, viewModel = cancelButtonViewModel)
+        },
+        title = {
+            Text(stringResource(Res.string.map_legend_title))
+        },
+        text = {
+            Column {
+                Text(stringResource(Res.string.map_legend_description))
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                items.forEach { (value, color) ->
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        Box(modifier = Modifier.height(24.dp).width(32.dp).background(color))
+                        Text(value)
+                    }
+                }
+            }
+        }
+    )
+}

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/map/MeasurementsMapView.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/map/MeasurementsMapView.kt
@@ -21,6 +21,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -55,6 +58,8 @@ fun MeasurementsMapView(
     }
     val mapOrientation by viewModel.mapOrientationFlow.collectAsStateWithLifecycle()
 
+    var showHelpDialog by remember { mutableStateOf(false) }
+
 
     // - Layout
 
@@ -70,6 +75,21 @@ fun MeasurementsMapView(
             .fillMaxHeight(fraction = 1f - viewModel.visibleAreaPaddingRatio.bottom)
             .padding(16.dp)
     ) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            modifier = Modifier.fillMaxHeight()
+        ) {
+            // Help button (shows legend and any additional info)
+            NCButton(
+                viewModel = viewModel.helpButtonViewModel,
+                onClick = {
+                    showHelpDialog = true
+                },
+                modifier = Modifier.size(CONTROLS_SIZE)
+                    .mapControl()
+            )
+        }
+
         Spacer(modifier = Modifier.weight(1f))
 
         Column(
@@ -80,15 +100,11 @@ fun MeasurementsMapView(
             Box(
                 contentAlignment = Alignment.Center,
                 modifier = Modifier.size(CONTROLS_SIZE)
-                    .dropShadow(shape = RoundedCornerShape(percent = 100))
-                    .clip(RoundedCornerShape(percent = 100))
-                    .background(MaterialTheme.colorScheme.surfaceContainer)
+                    .mapControl()
                     .rotate(mapOrientation)
             ) {
                 IconButton(
-                    onClick = {
-                        viewModel.resetOrientation()
-                    },
+                    onClick = { viewModel.resetOrientation() },
                 ) {
                     Icon(
                         painter = painterResource(Res.drawable.compass),
@@ -101,9 +117,7 @@ fun MeasurementsMapView(
             // Zoom controls
             Column(
                 modifier = Modifier.width(CONTROLS_SIZE)
-                    .dropShadow(shape = RoundedCornerShape(percent = 100))
-                    .clip(shape = RoundedCornerShape(percent = 100))
-                    .background(MaterialTheme.colorScheme.surfaceContainer)
+                    .mapControl()
             ) {
                 IconButton(
                     onClick = { viewModel.zoomIn() },
@@ -135,8 +149,22 @@ fun MeasurementsMapView(
                     viewModel.recenter()
                     viewModel.autoRecenterEnabled = true
                 },
-                modifier = Modifier.size(48.dp)
+                modifier = Modifier.size(CONTROLS_SIZE)
+                    .mapControl()
             )
         }
     }
+
+    if (showHelpDialog) {
+        MapLegendView(
+            onDismissRequest = { showHelpDialog = false }
+        )
+    }
 }
+
+
+@Composable
+private fun Modifier.mapControl() = this
+    .dropShadow(shape = RoundedCornerShape(100))
+    .clip(shape = RoundedCornerShape(percent = 100))
+    .background(MaterialTheme.colorScheme.surfaceContainer)

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/map/MeasurementsMapViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/map/MeasurementsMapViewModel.kt
@@ -2,6 +2,7 @@ package org.noiseplanet.noisecapture.ui.components.map
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MyLocation
+import androidx.compose.material.icons.filled.QuestionMark
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -192,7 +193,16 @@ class MeasurementsMapViewModel(
                 contentColor = MaterialTheme.colorScheme.onSurface
             )
         },
-        hasDropShadow = true,
+    )
+
+    val helpButtonViewModel = IconNCButtonViewModel(
+        icon = Icons.Default.QuestionMark,
+        colors = {
+            NCButtonColors(
+                containerColor = MaterialTheme.colorScheme.surfaceContainer,
+                contentColor = MaterialTheme.colorScheme.onSurface
+            )
+        },
     )
 
     private var _mapOrientationFlow = MutableStateFlow(0f)

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/theme/NoiseLevelColorRamp.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/theme/NoiseLevelColorRamp.kt
@@ -14,7 +14,7 @@ object NoiseLevelColorRamp {
      * Base color palette with true colors picked from [Coloring Noise](https://www.coloringnoise.com/)
      */
     val palette: Map<Double, Color> = mapOf(
-        0.0 to Color(0xFF82A6AD),
+        20.0 to Color(0xFF82A6AD),
         35.0 to Color(0xFFA0BABF),
         40.0 to Color(0xFFB8D6D1),
         45.0 to Color(0xFFCEE4CC),
@@ -31,7 +31,7 @@ object NoiseLevelColorRamp {
      * A darker version of the color palette to provide better contrast against light backgrounds
      */
     val paletteDarker: Map<Double, Color> = mapOf(
-        0.0 to Color(0xFF576F73),
+        20.0 to Color(0xFF576F73),
         35.0 to Color(0xFF6B7C7F),
         40.0 to Color(0xFF7B8F8B),
         45.0 to Color(0xFF899888),
@@ -48,7 +48,7 @@ object NoiseLevelColorRamp {
      * A lighter version of the color palette to use as background tint.
      */
     val paletteLighter: Map<Double, Color> = mapOf(
-        0.0 to Color(0xFFE6EDEF),
+        20.0 to Color(0xFFE6EDEF),
         35.0 to Color(0xFFECF1F2),
         40.0 to Color(0xFFF1F7F6),
         45.0 to Color(0xFFF5FAF5),


### PR DESCRIPTION
# Description

Adds a legend to the map, shown when pressing the help button

<img width="512" height="2424" alt="image" src="https://github.com/user-attachments/assets/aee0f2ed-2367-4814-b380-6bded1461564" />

## Changes

There is a new help button with a question mark icon in the upper left corner of the map. Clicking the button opens a dialog with the color legend.

Since there are many different colors, showing the legend at all times is not really an option. The help page approach also allow us to add some insights on how to read the map (what are the hexagonal tiles, at which point the sound level starts to be harmful for the user's health, etc) 

## Linked issues

- #161 

## Remaining TODOs

The description text is quite straightforward for now but we could imagine adding some extra information

## Checklist

- [x] Code compiles correctly on all platforms
- [ ] All pre-existing tests are passing
- [ ] If needed, new tests have been added
- [x] Extended the README / documentation if necessary
- [x] Added code has been documented
