### PR TITLE
Sampling rate in AndroidAudioRecordingService was 41000 instead of 44100

### DIFF
--- a/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/services/audio/AndroidAudioRecordingService.kt
+++ b/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/services/audio/AndroidAudioRecordingService.kt
@@ -45,7 +45,7 @@ class AndroidAudioRecordingService : AudioRecordingService, KoinComponent {
             setAudioSource(MediaRecorder.AudioSource.MIC)
             setOutputFormat(MediaRecorder.OutputFormat.MPEG_4)
             setAudioEncoder(MediaRecorder.AudioEncoder.HE_AAC)
-            setAudioSamplingRate(41_000)
+            setAudioSamplingRate(44_100)
             setOutputFile(outputFileUrl)
 
             // Finalise initialisation


### PR DESCRIPTION
# Description

Title says it all

## Changes

Fixed sampling rate typo that caused audio to be played back too fast compared to how it was recorded

## Linked issues

- #151 

## Remaining TODOs

N/A

## Checklist

- [x] Code compiles correctly on all platforms
- [x] All pre-existing tests are passing
- [ ] If needed, new tests have been added
- [ ] Extended the README / documentation if necessary
- [x] Added code has been documented
