### PR TITLE
Fixed ticks of spectrogram scale to be aligned with actual values

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/audio/signal/window/SpectrogramDataProcessing.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/audio/signal/window/SpectrogramDataProcessing.kt
@@ -41,6 +41,7 @@ class SpectrogramDataProcessing(
         } else {
             1.0
         }
+    private val vRef = (((windowSize * windowSize) / 2.0) * windowCorrectionFactor).toFloat()
 
     var samplesUntilWindow: Int = windowSize
     val hannWindow: FloatArray? =
@@ -145,7 +146,6 @@ class SpectrogramDataProcessing(
     private fun processWindowFloat(window: Window): FloatArray {
         require(window.samples.size == windowSize)
         val fr = (bluestein?.fft(window.samples) ?: realFFTFloat(window.samples))
-        val vRef = (((windowSize * windowSize) / 2.0) * windowCorrectionFactor).toFloat()
         return FloatArray(fr.size / 2) { i: Int ->
             10 * log10((fr[(i * 2) + 1] * fr[(i * 2) + 1]) / vRef)
         }


### PR DESCRIPTION
# Description

Title says it all

## Changes

Spectrogram Y axis ticks were not aligned with actual displayed values. This PR fixes this by updating the axis tick values.
This can be tested using a tone generator: https://onlinetonegenerator.com/

## Linked issues

- #192 

## Remaining TODOs

N/A

## Checklist

- [x] Code compiles correctly on all platforms
- [x] All pre-existing tests are passing
- [ ] If needed, new tests have been added
- [ ] Extended the README / documentation if necessary
- [x] Added code has been documented
