### PR TITLE
Catch potential exceptions when trying to start or stop recording

### DIFF
--- a/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/services/audio/AndroidAudioRecordingService.kt
+++ b/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/services/audio/AndroidAudioRecordingService.kt
@@ -57,16 +57,24 @@ class AndroidAudioRecordingService : AudioRecordingService, KoinComponent {
             logger.debug("MediaRecorder ready")
 
             // Start recording
-            start()
-            recordingStartListener?.onRecordingStart()
-            logger.debug("Started recording!")
+            try {
+                start()
+                recordingStartListener?.onRecordingStart()
+                logger.debug("Started recording!")
+            } catch (error: IllegalStateException) {
+                logger.error("Error while starting audio recording", error)
+            }
         }
     }
 
     override fun stopRecordingToFile() {
         // Stop recording and release recorder
         mediaRecorder?.apply {
-            stop()
+            try {
+                stop()
+            } catch (error: IllegalStateException) {
+                logger.error("Error while stopping audio recording", error)
+            }
             release()
             outputFileUrl?.let {
                 recordingStopListener?.onRecordingStop(it)


### PR DESCRIPTION
# Description

App is crashing if trying to stop recording that hasn't been started yet

## Changes

Catch potential exceptions when calling `MediaRecorder.start()` or `MediaRecorder.stop()` and log exception instead of crashing.

## Linked issues

- #203 

## Remaining TODOs

N/A

## Checklist

- [x] Code compiles correctly on all platforms
- [x] All pre-existing tests are passing
- [ ] If needed, new tests have been added
- [ ] Extended the README / documentation if necessary
- [x] Added code has been documented
