### PR TITLE
Write measurements data to external files dir so it can be retrieved …

### DIFF
--- a/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/services/storage/kstore/KStoreProvider.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/services/storage/kstore/KStoreProvider.android.kt
@@ -84,7 +84,7 @@ internal actual class KStoreProvider : KoinComponent {
 
     private fun getFileHandle(fileName: String): File {
         // Build complete file path
-        val filePath = Path("${context.filesDir}/$fileName")
+        val filePath = Path("${context.getExternalFilesDir(null)}/$fileName")
         return File(filePath.toString())
     }
 }


### PR DESCRIPTION
# Description

Temporary custom change for @pierromond that writes measurement data in external files directory, so it can be retrieved through adb without root access.

## Changes

Just changed root directory of KStore files to External files instead of internal 

## Linked issues

N/A

## Remaining TODOs

N/A

## Checklist

- [x] Code compiles correctly on all platforms
- [x] All pre-existing tests are passing
- [ ] If needed, new tests have been added
- [ ] Extended the README / documentation if necessary
- [x] Added code has been documented
