### PR TITLE
Feature/settings improvements

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -200,4 +200,5 @@
     <string name="na">N/A</string>
     <string name="delete">Delete</string>
     <string name="cancel">Cancel</string>
+    <string name="save">Save</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/model/enums/SpectrogramWindowingMode.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/model/enums/SpectrogramWindowingMode.kt
@@ -12,7 +12,7 @@ import org.noiseplanet.noisecapture.util.ShortNameRepresentable
 import kotlin.enums.EnumEntries
 
 @Serializable
-enum class MeasurementWindowingMode : IterableEnum<MeasurementWindowingMode>,
+enum class SpectrogramWindowingMode : IterableEnum<SpectrogramWindowingMode>,
                                       ShortNameRepresentable {
 
     HANN {
@@ -31,5 +31,5 @@ enum class MeasurementWindowingMode : IterableEnum<MeasurementWindowingMode>,
             Res.string.measurement_windowing_mode_rect_title
     };
 
-    override fun entries(): EnumEntries<MeasurementWindowingMode> = entries
+    override fun entries(): EnumEntries<SpectrogramWindowingMode> = entries
 }

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/settings/SettingsKey.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/settings/SettingsKey.kt
@@ -4,8 +4,8 @@ import kotlinx.serialization.KSerializer
 import kotlinx.serialization.builtins.serializer
 import org.noiseplanet.noisecapture.model.enums.AcousticsKnowledgeLevel
 import org.noiseplanet.noisecapture.model.enums.CalibrationTestAudioOutput
-import org.noiseplanet.noisecapture.model.enums.MeasurementWindowingMode
 import org.noiseplanet.noisecapture.model.enums.SpectrogramScaleMode
+import org.noiseplanet.noisecapture.model.enums.SpectrogramWindowingMode
 
 /**
  * User settings keys. Each value must be serializable.
@@ -48,9 +48,9 @@ sealed class SettingsKey<T>(val serializer: KSerializer<T>, val defaultValue: T)
     )
 
     // Measurements
-    data object SettingWindowingMode : SettingsKey<MeasurementWindowingMode>(
-        MeasurementWindowingMode.serializer(),
-        defaultValue = MeasurementWindowingMode.HANN,
+    data object SettingWindowingMode : SettingsKey<SpectrogramWindowingMode>(
+        SpectrogramWindowingMode.serializer(),
+        defaultValue = SpectrogramWindowingMode.HANN,
     )
 
     data object SettingLimitMeasurementDuration : SettingsKey<Boolean>(

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/settings/SettingsKey.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/settings/SettingsKey.kt
@@ -12,8 +12,17 @@ import org.noiseplanet.noisecapture.model.enums.SpectrogramWindowingMode
  *
  * For now [defaultValue] is enforced. If we need nullable setting values in the future
  * we may need to make it optional.
+ *
+ * @param serializer Serializer for the value type
+ * @param defaultValue Default value for this setting key
+ * @param validator Tells if a given value is a valid one for this setting.
+ *                  By default, just returns true.
  */
-sealed class SettingsKey<T>(val serializer: KSerializer<T>, val defaultValue: T) {
+sealed class SettingsKey<T>(
+    val serializer: KSerializer<T>,
+    val defaultValue: T,
+    val validator: (T) -> Boolean = { true },
+) {
 
     // User profile
     data object SettingUserAcousticsKnowledge : SettingsKey<AcousticsKnowledgeLevel>(
@@ -61,6 +70,7 @@ sealed class SettingsKey<T>(val serializer: KSerializer<T>, val defaultValue: T)
     data object SettingMaxMeasurementDuration : SettingsKey<UInt>(
         UInt.serializer(),
         defaultValue = 60u,
+        validator = { it > 0u } // Enforce non zero value
     )
 
     data object SettingSaveAudioWithMeasurement : SettingsKey<Boolean>(
@@ -71,6 +81,7 @@ sealed class SettingsKey<T>(val serializer: KSerializer<T>, val defaultValue: T)
     data object SettingLimitSavedAudioDurationMinutes : SettingsKey<UInt>(
         UInt.serializer(),
         defaultValue = 10u,
+        validator = { it > 0u } // Enforce non zero value
     )
 
     data object SettingSpectrogramScaleMode : SettingsKey<SpectrogramScaleMode>(

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/settings/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/settings/SettingsScreen.kt
@@ -13,7 +13,7 @@ import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -92,8 +92,12 @@ fun SettingsScreen(
                         )
                     }
 
-                    items(sectionItems) { viewModel ->
-                        SettingsItem(viewModel)
+                    itemsIndexed(sectionItems) { index, viewModel ->
+                        SettingsItem(
+                            viewModel = viewModel,
+                            isFirstInSection = index == 0,
+                            isLastInSection = index == (sectionItems.size - 1),
+                        )
                     }
                 }
             }

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/settings/SettingsScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/settings/SettingsScreenViewModel.kt
@@ -2,26 +2,6 @@ package org.noiseplanet.noisecapture.ui.features.settings
 
 import androidx.lifecycle.ViewModel
 import noisecapture.composeapp.generated.resources.Res
-import noisecapture.composeapp.generated.resources.settings_calibration_countdown_description
-import noisecapture.composeapp.generated.resources.settings_calibration_countdown_title
-import noisecapture.composeapp.generated.resources.settings_calibration_duration_description
-import noisecapture.composeapp.generated.resources.settings_calibration_duration_title
-import noisecapture.composeapp.generated.resources.settings_calibration_gain_correction_description
-import noisecapture.composeapp.generated.resources.settings_calibration_gain_correction_title
-import noisecapture.composeapp.generated.resources.settings_calibration_output_description
-import noisecapture.composeapp.generated.resources.settings_calibration_output_title
-import noisecapture.composeapp.generated.resources.settings_general_automatic_transfer_description
-import noisecapture.composeapp.generated.resources.settings_general_automatic_transfer_title
-import noisecapture.composeapp.generated.resources.settings_general_disclaimer_description
-import noisecapture.composeapp.generated.resources.settings_general_disclaimer_title
-import noisecapture.composeapp.generated.resources.settings_general_notification_description
-import noisecapture.composeapp.generated.resources.settings_general_notification_title
-import noisecapture.composeapp.generated.resources.settings_general_tooltips_description
-import noisecapture.composeapp.generated.resources.settings_general_tooltips_title
-import noisecapture.composeapp.generated.resources.settings_general_wifi_only_description
-import noisecapture.composeapp.generated.resources.settings_general_wifi_only_title
-import noisecapture.composeapp.generated.resources.settings_map_measurements_count_description
-import noisecapture.composeapp.generated.resources.settings_map_measurements_count_title
 import noisecapture.composeapp.generated.resources.settings_measurements_limit_audio_duration_description
 import noisecapture.composeapp.generated.resources.settings_measurements_limit_audio_duration_title
 import noisecapture.composeapp.generated.resources.settings_measurements_limit_duration_description
@@ -34,9 +14,6 @@ import noisecapture.composeapp.generated.resources.settings_measurements_spectro
 import noisecapture.composeapp.generated.resources.settings_measurements_spectrogram_mode_title
 import noisecapture.composeapp.generated.resources.settings_measurements_windowing_description
 import noisecapture.composeapp.generated.resources.settings_measurements_windowing_title
-import noisecapture.composeapp.generated.resources.settings_section_calibration
-import noisecapture.composeapp.generated.resources.settings_section_general
-import noisecapture.composeapp.generated.resources.settings_section_map
 import noisecapture.composeapp.generated.resources.settings_section_measurements
 import noisecapture.composeapp.generated.resources.settings_section_user_profile
 import noisecapture.composeapp.generated.resources.settings_title
@@ -64,40 +41,6 @@ class SettingsScreenViewModel : ViewModel(), ScreenViewModel, KoinComponent {
                     title = Res.string.settings_user_acoustics_knowledge_title,
                     description = Res.string.settings_user_acoustics_knowledge_description,
                     settingKey = SettingsKey.SettingUserAcousticsKnowledge,
-                    isFirstInSection = true,
-                    isLastInSection = true,
-                ),
-            )
-        ),
-        Pair(
-            Res.string.settings_section_general, listOf(
-                SettingsItemViewModel(
-                    title = Res.string.settings_general_tooltips_title,
-                    description = Res.string.settings_general_tooltips_description,
-                    settingKey = SettingsKey.SettingTooltipsEnabled,
-                    isFirstInSection = true,
-                ),
-                SettingsItemViewModel(
-                    title = Res.string.settings_general_disclaimer_title,
-                    description = Res.string.settings_general_disclaimer_description,
-                    settingKey = SettingsKey.SettingDisclaimersEnabled,
-                ),
-                SettingsItemViewModel(
-                    title = Res.string.settings_general_notification_title,
-                    description = Res.string.settings_general_notification_description,
-                    settingKey = SettingsKey.SettingNotificationEnabled,
-                ),
-                SettingsItemViewModel(
-                    title = Res.string.settings_general_automatic_transfer_title,
-                    description = Res.string.settings_general_automatic_transfer_description,
-                    settingKey = SettingsKey.SettingAutomaticTransferEnabled,
-                ),
-                SettingsItemViewModel(
-                    title = Res.string.settings_general_wifi_only_title,
-                    description = Res.string.settings_general_wifi_only_description,
-                    settingKey = SettingsKey.SettingTransferOverWifiOnly,
-                    isLastInSection = true,
-                    isEnabled = settingsService.getFlow(SettingsKey.SettingAutomaticTransferEnabled)
                 ),
             )
         ),
@@ -137,39 +80,6 @@ class SettingsScreenViewModel : ViewModel(), ScreenViewModel, KoinComponent {
                 ),
             )
         ),
-        Pair(
-            Res.string.settings_section_calibration, listOf(
-                SettingsItemViewModel(
-                    title = Res.string.settings_calibration_gain_correction_title,
-                    description = Res.string.settings_calibration_gain_correction_description,
-                    settingKey = SettingsKey.SettingSignalGainCorrection,
-                ),
-                SettingsItemViewModel(
-                    title = Res.string.settings_calibration_countdown_title,
-                    description = Res.string.settings_calibration_countdown_description,
-                    settingKey = SettingsKey.SettingCalibrationCountdown,
-                ),
-                SettingsItemViewModel(
-                    title = Res.string.settings_calibration_duration_title,
-                    description = Res.string.settings_calibration_duration_description,
-                    settingKey = SettingsKey.SettingCalibrationDuration,
-                ),
-                SettingsEnumItemViewModel(
-                    title = Res.string.settings_calibration_output_title,
-                    description = Res.string.settings_calibration_output_description,
-                    settingKey = SettingsKey.SettingTestSignalAudioOutput,
-                ),
-            )
-        ),
-        Pair(
-            Res.string.settings_section_map, listOf(
-                SettingsItemViewModel(
-                    title = Res.string.settings_map_measurements_count_title,
-                    description = Res.string.settings_map_measurements_count_description,
-                    settingKey = SettingsKey.SettingMapMaxMeasurementsCount,
-                ),
-            )
-        )
     )
 
 

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/settings/SettingsScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/settings/SettingsScreenViewModel.kt
@@ -107,7 +107,6 @@ class SettingsScreenViewModel : ViewModel(), ScreenViewModel, KoinComponent {
                     title = Res.string.settings_measurements_limit_duration_title,
                     description = Res.string.settings_measurements_limit_duration_description,
                     settingKey = SettingsKey.SettingLimitMeasurementDuration,
-                    isFirstInSection = true,
                 ),
                 SettingsItemViewModel(
                     title = Res.string.settings_measurements_max_duration_title,
@@ -135,7 +134,6 @@ class SettingsScreenViewModel : ViewModel(), ScreenViewModel, KoinComponent {
                     title = Res.string.settings_measurements_windowing_title,
                     description = Res.string.settings_measurements_windowing_description,
                     settingKey = SettingsKey.SettingWindowingMode,
-                    isLastInSection = true,
                 ),
             )
         ),
@@ -145,7 +143,6 @@ class SettingsScreenViewModel : ViewModel(), ScreenViewModel, KoinComponent {
                     title = Res.string.settings_calibration_gain_correction_title,
                     description = Res.string.settings_calibration_gain_correction_description,
                     settingKey = SettingsKey.SettingSignalGainCorrection,
-                    isFirstInSection = true,
                 ),
                 SettingsItemViewModel(
                     title = Res.string.settings_calibration_countdown_title,
@@ -161,7 +158,6 @@ class SettingsScreenViewModel : ViewModel(), ScreenViewModel, KoinComponent {
                     title = Res.string.settings_calibration_output_title,
                     description = Res.string.settings_calibration_output_description,
                     settingKey = SettingsKey.SettingTestSignalAudioOutput,
-                    isLastInSection = true
                 ),
             )
         ),
@@ -171,8 +167,6 @@ class SettingsScreenViewModel : ViewModel(), ScreenViewModel, KoinComponent {
                     title = Res.string.settings_map_measurements_count_title,
                     description = Res.string.settings_map_measurements_count_description,
                     settingKey = SettingsKey.SettingMapMaxMeasurementsCount,
-                    isFirstInSection = true,
-                    isLastInSection = true,
                 ),
             )
         )

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/settings/item/SettingsItem.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/settings/item/SettingsItem.kt
@@ -28,14 +28,16 @@ import org.noiseplanet.noisecapture.util.IterableEnum
 @Composable
 fun <T : Any> SettingsItem(
     viewModel: SettingsItemViewModel<T>,
+    isFirstInSection: Boolean = false,
+    isLastInSection: Boolean = false,
 ) {
     val shape = MaterialTheme.shapes.medium
         .let {
-            if (viewModel.isFirstInSection) it else {
+            if (isFirstInSection) it else {
                 it.copy(topStart = CornerSize(0.dp), topEnd = CornerSize(0.dp))
             }
         }.let {
-            if (viewModel.isLastInSection) it else {
+            if (isLastInSection) it else {
                 it.copy(bottomStart = CornerSize(0.dp), bottomEnd = CornerSize(0.dp))
             }
         }
@@ -52,8 +54,8 @@ fun <T : Any> SettingsItem(
             modifier = Modifier.fillMaxWidth()
                 .alpha(if (isEnabled) 1.0f else 0.3f)
                 .padding(
-                    top = if (viewModel.isFirstInSection) 16.dp else 12.dp,
-                    bottom = if (viewModel.isLastInSection) 16.dp else 12.dp,
+                    top = if (isFirstInSection) 16.dp else 12.dp,
+                    bottom = if (isLastInSection) 16.dp else 12.dp,
                 )
         ) {
             Column(
@@ -98,7 +100,7 @@ fun <T : Any> SettingsItem(
             }
         }
 
-        if (!viewModel.isLastInSection) {
+        if (!isLastInSection) {
             HorizontalDivider(
                 thickness = 1.dp,
                 color = MaterialTheme.colorScheme.background

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/settings/item/SettingsItemViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/settings/item/SettingsItemViewModel.kt
@@ -18,8 +18,6 @@ import org.noiseplanet.noisecapture.util.ShortNameRepresentable
 open class SettingsItemViewModel<T>(
     val title: StringResource,
     val description: StringResource,
-    val isFirstInSection: Boolean = false,
-    val isLastInSection: Boolean = false,
     val isEnabled: Flow<Boolean> = flow { emit(true) },
     val settingKey: SettingsKey<T>,
 ) : KoinComponent {
@@ -57,15 +55,11 @@ open class SettingsItemViewModel<T>(
 class SettingsEnumItemViewModel<T>(
     title: StringResource,
     description: StringResource,
-    isFirstInSection: Boolean = false,
-    isLastInSection: Boolean = false,
     isEnabled: Flow<Boolean> = flow { emit(true) },
     settingKey: SettingsKey<T>,
 ) : SettingsItemViewModel<T>(
     title = title,
     description = description,
-    isFirstInSection = isFirstInSection,
-    isLastInSection = isLastInSection,
     isEnabled = isEnabled,
     settingKey = settingKey
 ) where T : Enum<T>, T : IterableEnum<T>, T : ShortNameRepresentable {

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/settings/item/SettingsItemViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/settings/item/SettingsItemViewModel.kt
@@ -14,7 +14,6 @@ import org.noiseplanet.noisecapture.util.ShortNameRepresentable
 /**
  * Base setting item view model class to use with primitive types.
  */
-@Suppress("LongParameterList")
 open class SettingsItemViewModel<T>(
     val title: StringResource,
     val description: StringResource,
@@ -51,7 +50,6 @@ open class SettingsItemViewModel<T>(
  *
  * The given enum must comply to both [IterableEnum] and [ShortNameRepresentable].
  */
-@Suppress("LongParameterList")
 class SettingsEnumItemViewModel<T>(
     title: StringResource,
     description: StringResource,

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/settings/item/SettingsNumericalInput.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/settings/item/SettingsNumericalInput.kt
@@ -1,39 +1,40 @@
 package org.noiseplanet.noisecapture.ui.features.settings.item
 
-import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.onFocusChanged
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
-import androidx.compose.ui.input.nestedscroll.NestedScrollSource
-import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.input.TextFieldValue
-import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.Velocity
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import noisecapture.composeapp.generated.resources.Res
+import noisecapture.composeapp.generated.resources.cancel
+import noisecapture.composeapp.generated.resources.save
+import org.jetbrains.compose.resources.stringResource
+import org.noiseplanet.noisecapture.ui.components.button.NCButton
+import org.noiseplanet.noisecapture.ui.components.button.NCButtonColors
+import org.noiseplanet.noisecapture.ui.components.button.NCButtonStyle
+import org.noiseplanet.noisecapture.ui.components.button.NCButtonViewModel
 
 /**
  * A custom text field for numerical settings values.
@@ -46,116 +47,114 @@ fun <T : Any> SettingsNumericalInput(
     viewModel: SettingsItemViewModel<T>,
     modifier: Modifier = Modifier,
 ) {
+    // - Properties
+
     var textFieldValueState by remember {
-        val initialValue = viewModel.getValue().toString()
-
-        mutableStateOf(
-            TextFieldValue(
-                text = initialValue,
-                selection = TextRange(initialValue.length)
-            )
-        )
+        mutableStateOf(viewModel.getValue().toString())
     }
-
-    val focusManager = LocalFocusManager.current
-    val interactionSource = remember { MutableInteractionSource() }
-
-    val colors = TextFieldDefaults.colors(
-        unfocusedContainerColor = Color.Transparent,
-        unfocusedIndicatorColor = Color.Transparent,
-    )
     val isEnabled by viewModel.isEnabled.collectAsState(true)
+
+    var showEditDialog: Boolean by remember { mutableStateOf(false) }
+    val confirmButtonViewModel = NCButtonViewModel(
+        title = Res.string.save,
+        colors = { NCButtonColors.Defaults.secondary() }
+    )
+    val cancelButtonViewModel = NCButtonViewModel(
+        title = Res.string.cancel,
+        style = NCButtonStyle.TEXT,
+        colors = { NCButtonColors.Defaults.text() }
+    )
+
+
+    // - Private functions
 
     @Suppress("UNCHECKED_CAST")
     fun getNumericalValue(): T? {
+        // TODO: Add value range validation
         return when (viewModel.settingKey.defaultValue) {
-            is Int -> textFieldValueState.text.toIntOrNull() as T?
-            is UInt -> textFieldValueState.text.toUIntOrNull() as T?
-            is Long -> textFieldValueState.text.toLongOrNull() as T?
-            is ULong -> textFieldValueState.text.toULongOrNull() as T?
-            is Double -> textFieldValueState.text.toDoubleOrNull() as T?
-            is Float -> textFieldValueState.text.toFloatOrNull() as T?
+            is Int -> textFieldValueState.toIntOrNull() as T?
+            is UInt -> textFieldValueState.toUIntOrNull() as T?
+            is Long -> textFieldValueState.toLongOrNull() as T?
+            is ULong -> textFieldValueState.toULongOrNull() as T?
+            is Double -> textFieldValueState.toDoubleOrNull() as T?
+            is Float -> textFieldValueState.toFloatOrNull() as T?
             else -> null
         }
     }
 
+    fun saveEdit() {
+        getNumericalValue()?.let { newValue ->
+            viewModel.setValue(newValue)
+            showEditDialog = false
+        }
+    }
+
+    fun cancelEdit() {
+        textFieldValueState = viewModel.getValue().toString()
+        showEditDialog = false
+    }
+
+
+    // - Layout
+
     Box(
         modifier = modifier.width(IntrinsicSize.Min)
+            .clickable {
+                showEditDialog = true
+            }
+            .padding(vertical = 16.dp)
     ) {
-        BasicTextField(
-            value = textFieldValueState,
-            onValueChange = { newValue ->
-                textFieldValueState = newValue
-                // If entered value is valid, save it
-                getNumericalValue()?.let {
-                    viewModel.setValue(it)
-                }
-            },
-            textStyle = MaterialTheme.typography.titleMedium.copy(
+        Text(
+            text = viewModel.getValue().toString(),
+            style = MaterialTheme.typography.titleMedium.copy(
                 textAlign = TextAlign.End,
                 color = MaterialTheme.colorScheme.onSurface
                     .copy(alpha = if (isEnabled) 1.0f else 0.5f)
             ),
-            keyboardOptions = KeyboardOptions(
-                keyboardType = KeyboardType.Decimal,
-                imeAction = ImeAction.Done,
-            ),
-            keyboardActions = KeyboardActions(onDone = {
-                if (getNumericalValue() != null) {
-                    // Clear focus and dismiss keyboard if input is valid
-                    focusManager.clearFocus()
+            modifier = Modifier.widthIn(min = 32.dp, max = 64.dp),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+
+    if (showEditDialog) {
+        AlertDialog(
+            title = {
+                Text(text = stringResource(viewModel.title))
+            },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                    Text(text = stringResource(viewModel.description))
+
+                    TextField(
+                        value = textFieldValueState,
+                        onValueChange = { newValue ->
+                            textFieldValueState = newValue
+                        },
+                        keyboardOptions = KeyboardOptions(
+                            keyboardType = KeyboardType.Decimal,
+                            imeAction = ImeAction.Done,
+                        ),
+                        keyboardActions = KeyboardActions(onDone = { saveEdit() }),
+                        isError = getNumericalValue() == null,
+                        maxLines = 1,
+                    )
                 }
-            }),
-            singleLine = true,
-            enabled = isEnabled,
-            modifier = modifier
-                .widthIn(min = 32.dp, max = 64.dp)
-                .align(Alignment.CenterEnd)
-                .padding(vertical = 16.dp)
-                .padding(start = 4.dp)
-                .disabledHorizontalPointerInputScroll()
-                .onFocusChanged { focusState ->
-                    if (!focusState.isFocused) {
-                        textFieldValueState = textFieldValueState.copy(
-                            text = viewModel.getValue().toString()
-                        )
-                    }
-                }
-        ) {
-            TextFieldDefaults.DecorationBox(
-                value = textFieldValueState.text,
-                innerTextField = it,
-                singleLine = true,
-                enabled = true,
-                visualTransformation = VisualTransformation.None,
-                interactionSource = interactionSource,
-                isError = getNumericalValue() == null,
-                contentPadding = TextFieldDefaults.contentPaddingWithoutLabel(
-                    start = 0.dp,
-                    end = 0.dp,
-                    top = 0.dp,
-                    bottom = 0.dp,
-                ),
-                prefix = null,
-                colors = colors,
-            )
-        }
+            },
+            onDismissRequest = { cancelEdit() },
+            confirmButton = {
+                NCButton(
+                    viewModel = confirmButtonViewModel,
+                    onClick = { saveEdit() }
+                )
+            },
+            dismissButton = {
+                NCButton(
+                    viewModel = cancelButtonViewModel,
+                    onClick = { cancelEdit() }
+                )
+            },
+            modifier = Modifier.imePadding()
+        )
     }
 }
-
-
-/**
- * Fixes a weird scrolling behaviour when using BasicTextField with width based on IntrinsicSize.min:
- * https://stackoverflow.com/questions/73309395/strange-scroll-in-the-basictextfield-with-intrinsicsize-min
- */
-private val HorizontalScrollConsumer = object : NestedScrollConnection {
-    override fun onPreScroll(available: Offset, source: NestedScrollSource) = available.copy(y = 0f)
-    override suspend fun onPreFling(available: Velocity) = available.copy(y = 0f)
-}
-
-fun Modifier.disabledHorizontalPointerInputScroll(disabled: Boolean = true) =
-    if (disabled) {
-        this.nestedScroll(HorizontalScrollConsumer)
-    } else {
-        this
-    }

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/theme/NoiseLevelColorRamp.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/theme/NoiseLevelColorRamp.kt
@@ -18,7 +18,7 @@ object NoiseLevelColorRamp {
         35.0 to Color(0xFFA0BABF),
         40.0 to Color(0xFFB8D6D1),
         45.0 to Color(0xFFCEE4CC),
-        50.0 to Color(0xFFECDFA0),
+        50.0 to Color(0xFFE2F2BF),
         55.0 to Color(0xFFF3C683),
         60.0 to Color(0xFFE87E4D),
         65.0 to Color(0xFFCD463E),

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/util/shadow/DropShadow.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/util/shadow/DropShadow.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
  *
  * @return A new `Modifier` with the drop shadow effect applied.
  */
-@Suppress("LongParameterList")
 @Composable
 fun Modifier.dropShadow(
     shape: Shape,

--- a/config/detekt.yml
+++ b/config/detekt.yml
@@ -127,6 +127,8 @@ complexity:
     ignoreDefaultParameters: false
     ignoreDataClasses: true
     ignoreAnnotatedParameter: [ ]
+    ignoreAnnotated:
+      - "Composable"
   MethodOverloading:
     active: false
     threshold: 6


### PR DESCRIPTION
# Description

Fixes various settings related issues after first round of testing

## Changes

- Hide unused settings from the settings page (calibration settings, map settings, etc), they will be added again later on when they are actually used in the app
- Some settings were not actually used where they could:
  - Windowing mode (Hann / Rectangular)
  - Measurement duration limit
- If a value is too long to be displayed, show ellipsis instead of just clipping.
- Improve edition of text (or number) values by showing the field in a popup instead of inline editing
- Enforce time limits (audio or measurement) to be greater than zero (and more generally add a generic validation mechanism to settings keys)
- Fix a bug where measurement duration limit would not properly stop the foreground service on Android
- Fix a wrong color palette value (50-55 dB)

## Linked issues

- #211 
- #218 
- #219

## Remaining TODOs

N/A

## Checklist

- [x] Code compiles correctly on all platforms
- [x] All pre-existing tests are passing
- [ ] If needed, new tests have been added
- [ ] Extended the README / documentation if necessary
- [x] Added code has been documented
