### PR TITLE
Feature/description placeholder

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -94,6 +94,8 @@
     <string name="measurement_details_delete_measurement_dialog_text">This action cannot be undone. Note that this will only the local copy of your measurement, if you've already synced it before, the distant copy will be kept but you won't be able to download it again.</string>
     <string name="measurement_details_delete_measurement_audio_dialog_text">This action cannot be undone. This will not delete the measurement itself but only the audio clip that is attached to it. You won't be able to listen to the measurement audio afterwards but will still be able to see the measurement details.</string>
 
+    <string name="measurement_no_description_placeholder">No description.</string>
+
 
     <!-- CommunityMapScreen -->
     <string name="community_map_title">Community measurements</string>

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/details/DetailsHeader.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/details/DetailsHeader.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import noisecapture.composeapp.generated.resources.Res
 import noisecapture.composeapp.generated.resources.measurement_details_average_level
+import noisecapture.composeapp.generated.resources.measurement_no_description_placeholder
 import org.jetbrains.compose.resources.stringResource
 import org.noiseplanet.noisecapture.ui.theme.NoiseLevelColorRamp
 import org.noiseplanet.noisecapture.util.roundTo
@@ -51,37 +52,6 @@ fun DetailsChartsHeader(
         horizontalArrangement = Arrangement.spacedBy(16.dp),
         modifier = Modifier.height(IntrinsicSize.Min)
     ) {
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = startTime,
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.SemiBold,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-            Text(
-                text = duration,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-
-            Spacer(Modifier.weight(1f))
-
-            Text(
-                // TODO: Get description from measurement
-                text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do " +
-                    "eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad" +
-                    " minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip" +
-                    " ex ea commodo consequat. Duis aute irure dolor in reprehenderit in " +
-                    "voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur " +
-                    "sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt " +
-                    "mollit anim id est laborum.",
-                maxLines = 3,
-                overflow = TextOverflow.Ellipsis,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f),
-            )
-        }
-
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier.clip(RoundedCornerShape(size = 16.dp))
@@ -100,6 +70,31 @@ fun DetailsChartsHeader(
                 text = stringResource(Res.string.measurement_details_average_level),
                 style = MaterialTheme.typography.labelSmall,
                 color = averageLevelColorTint,
+            )
+        }
+
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = startTime,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Text(
+                text = duration,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Text(
+                // TODO: Get description from measurement
+                text = stringResource(Res.string.measurement_no_description_placeholder),
+                maxLines = 3,
+                overflow = TextOverflow.Ellipsis,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.75f),
             )
         }
     }

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/history/HistoryItemView.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/history/HistoryItemView.kt
@@ -26,6 +26,9 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.format
 import kotlinx.datetime.toLocalDateTime
 import nl.jacobras.humanreadable.HumanReadable
+import noisecapture.composeapp.generated.resources.Res
+import noisecapture.composeapp.generated.resources.measurement_no_description_placeholder
+import org.jetbrains.compose.resources.stringResource
 import org.noiseplanet.noisecapture.model.dao.Measurement
 import org.noiseplanet.noisecapture.ui.components.spl.LAeqMetricsView
 import org.noiseplanet.noisecapture.util.DateUtil
@@ -89,7 +92,7 @@ fun HistoryItemView(
 
             Text(
                 // TODO: Get description from measurement
-                text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod",
+                text = stringResource(Res.string.measurement_no_description_placeholder),
                 maxLines = 3,
                 overflow = TextOverflow.Ellipsis,
                 style = MaterialTheme.typography.bodySmall,


### PR DESCRIPTION
# Description

Show "No description." instead of "Lorem ipsum..." as a placeholder for measurement description.

## Changes

- Updated (and localised) placeholder text
- Switched average level view (now on the left) and title/duration/description in measurement details header for a better layout harmony when description is only one or two lines long.

## Linked issues

- #221 

## Remaining TODOs

Once there will be an actual way to add notes/description to a measurement, show it here.

## Checklist

- [x] Code compiles correctly on all platforms
- [x] All pre-existing tests are passing
- [ ] If needed, new tests have been added
- [ ] Extended the README / documentation if necessary
- [x] Added code has been documented
