### PR TITLE
Feature/dynamic bottom padding

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/map/MapView.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/map/MapView.kt
@@ -6,16 +6,11 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.navigationBars
-import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
@@ -42,6 +37,7 @@ import org.jetbrains.compose.resources.painterResource
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
 import org.noiseplanet.noisecapture.ui.components.button.NCButton
+import org.noiseplanet.noisecapture.util.paddingBottomWithInsets
 import org.noiseplanet.noisecapture.util.shadow.dropShadow
 import ovh.plrapps.mapcompose.ui.MapUI
 
@@ -78,9 +74,7 @@ fun MapView(
             var controlsModifier = modifier
             // If the view expands down to the bottom of the screen, take safe area padding into account
             if (viewModel.parameters.visibleAreaPaddingRatio.bottom == 0.0f) {
-                controlsModifier = controlsModifier.windowInsetsPadding(
-                    WindowInsets.navigationBars.only(WindowInsetsSides.Bottom)
-                )
+                controlsModifier = controlsModifier.paddingBottomWithInsets()
             }
 
             Row(

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/details/DetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/details/DetailsScreen.kt
@@ -8,16 +8,11 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.navigationBars
-import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CircularProgressIndicator
@@ -42,6 +37,7 @@ import org.koin.core.annotation.KoinExperimentalAPI
 import org.noiseplanet.noisecapture.ui.components.audioplayer.AudioPlayerView
 import org.noiseplanet.noisecapture.ui.components.map.MapView
 import org.noiseplanet.noisecapture.ui.navigation.router.DetailsRouter
+import org.noiseplanet.noisecapture.util.paddingBottomWithInsets
 
 
 @OptIn(KoinExperimentalAPI::class)
@@ -184,8 +180,7 @@ private fun DetailsScreenMedium(
     Column(
         verticalArrangement = Arrangement.spacedBy(24.dp),
         modifier = Modifier.verticalScroll(scrollState)
-            .windowInsetsPadding(WindowInsets.navigationBars.only(WindowInsetsSides.Bottom))
-            .padding(24.dp)
+            .paddingBottomWithInsets(24.dp)
     ) {
         Row(
             horizontalArrangement = Arrangement.spacedBy(24.dp),
@@ -276,8 +271,9 @@ private fun DetailsScreenCompact(
 
     Column(
         modifier = Modifier.verticalScroll(scrollState)
-            .windowInsetsPadding(WindowInsets.navigationBars.only(WindowInsetsSides.Bottom))
-            .padding(16.dp),
+            .padding(horizontal = 16.dp)
+            .padding(top = 16.dp)
+            .paddingBottomWithInsets(withNavBar = 16.dp, withoutNavBar = 24.dp),
         verticalArrangement = Arrangement.spacedBy(24.dp)
     ) {
         DetailsChartsHeader(

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/home/HomeScreen.kt
@@ -6,15 +6,12 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
@@ -27,6 +24,8 @@ import androidx.window.core.layout.WindowSizeClass
 import org.koin.compose.module.rememberKoinModules
 import org.koin.core.annotation.KoinExperimentalAPI
 import org.noiseplanet.noisecapture.ui.navigation.router.HomeRouter
+import org.noiseplanet.noisecapture.util.navigationBarInsetsTop
+import org.noiseplanet.noisecapture.util.paddingBottomWithInsets
 
 /**
  * Home screen layout.
@@ -79,8 +78,8 @@ private fun HomeScreenCompact(viewModel: HomeScreenViewModel, router: HomeRouter
     Column(
         verticalArrangement = Arrangement.spacedBy(24.dp),
         modifier = Modifier.verticalScroll(rememberScrollState())
-            .windowInsetsPadding(WindowInsets.navigationBars)
-            .padding(bottom = 32.dp)
+            .navigationBarInsetsTop()
+            .paddingBottomWithInsets(32.dp)
             .padding(top = topPadding)
             .padding(horizontal = horizontalPadding)
     ) {
@@ -115,9 +114,10 @@ private fun HomeScreenCompact(viewModel: HomeScreenViewModel, router: HomeRouter
 private fun HomeScreenLarge(viewModel: HomeScreenViewModel, router: HomeRouter) {
     Column(
         verticalArrangement = Arrangement.spacedBy(24.dp),
-        modifier = Modifier.windowInsetsPadding(WindowInsets.navigationBars)
+        modifier = Modifier.navigationBarInsetsTop()
+            .paddingBottomWithInsets(withNavBar = 16.dp, withoutNavBar = 24.dp)
             .padding(horizontal = 24.dp)
-            .padding(top = 24.dp, bottom = 16.dp)
+            .padding(top = 24.dp)
     ) {
         Row(
             horizontalArrangement = Arrangement.spacedBy(24.dp),

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/recording/RecordingPager.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/recording/RecordingPager.kt
@@ -2,11 +2,8 @@ package org.noiseplanet.noisecapture.ui.features.recording
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.MaterialTheme
@@ -29,6 +26,8 @@ import org.jetbrains.compose.resources.stringResource
 import org.noiseplanet.noisecapture.ui.components.map.MapView
 import org.noiseplanet.noisecapture.ui.features.recording.plot.spectrogram.SpectrogramPlotView
 import org.noiseplanet.noisecapture.ui.features.recording.plot.spectrum.SpectrumPlotView
+import org.noiseplanet.noisecapture.util.navigationBarInsetsTop
+import org.noiseplanet.noisecapture.util.paddingBottomWithInsets
 
 /**
  * A horizontal pager on the measurement recording screens that allows user to switch between
@@ -56,8 +55,9 @@ fun RecordingPager(
         )
     }
     val pagePaddingModifier = if (isCompact) {
-        Modifier.padding(end = 16.dp, bottom = 80.dp)
-            .windowInsetsPadding(WindowInsets.navigationBars)
+        Modifier.navigationBarInsetsTop()
+            .paddingBottomWithInsets(80.dp) // 64dp for recording controls + 16dp of spacing
+            .padding(end = 16.dp)
     } else {
         Modifier.padding(end = 16.dp, bottom = 16.dp)
     }
@@ -76,7 +76,7 @@ fun RecordingPager(
             selectedTabIndex = pagerState.currentPage,
             containerColor = MaterialTheme.colorScheme.surfaceContainer
         ) {
-            tabs.toList().forEachIndexed { index, (id, label) ->
+            tabs.toList().forEachIndexed { index, (_, label) ->
                 Tab(
                     text = { Text(label) },
                     selected = pagerState.currentPage == index,

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/recording/RecordingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/recording/RecordingScreen.kt
@@ -7,15 +7,10 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.navigationBars
-import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
@@ -42,6 +37,8 @@ import org.noiseplanet.noisecapture.ui.components.map.MapView
 import org.noiseplanet.noisecapture.ui.components.spl.SoundLevelMeterView
 import org.noiseplanet.noisecapture.ui.features.recording.controls.RecordingControls
 import org.noiseplanet.noisecapture.ui.navigation.router.RecordingRouter
+import org.noiseplanet.noisecapture.util.navigationBarInsetsTop
+import org.noiseplanet.noisecapture.util.paddingBottomWithInsets
 
 
 @OptIn(KoinExperimentalAPI::class)
@@ -146,8 +143,8 @@ private fun RecordingScreenCompact(viewModel: RecordingScreenViewModel) {
         }
         RecordingControls(
             onStopRecording = { viewModel.showEndRecordingConfirmationDialog?.invoke() },
-            modifier = Modifier.windowInsetsPadding(WindowInsets.navigationBars)
-                .padding(bottom = 8.dp)
+            modifier = Modifier.navigationBarInsetsTop()
+                .paddingBottomWithInsets(withNavBar = 8.dp, withoutNavBar = 16.dp)
         )
     }
 }
@@ -159,10 +156,8 @@ private fun RecordingScreenMedium(viewModel: RecordingScreenViewModel) {
         verticalArrangement = Arrangement.spacedBy(24.dp),
         modifier = Modifier
             .padding(horizontal = 24.dp)
-            .padding(top = 24.dp, bottom = 16.dp)
-            .windowInsetsPadding(
-                WindowInsets.navigationBars.only(WindowInsetsSides.Bottom)
-            ),
+            .padding(top = 24.dp)
+            .paddingBottomWithInsets(withNavBar = 16.dp, withoutNavBar = 24.dp),
     ) {
         Column(
             modifier = Modifier.weight(3f)
@@ -196,10 +191,8 @@ private fun RecordingScreenLarge(viewModel: RecordingScreenViewModel) {
         horizontalArrangement = Arrangement.spacedBy(24.dp),
         modifier = Modifier
             .padding(horizontal = 24.dp)
-            .padding(top = 24.dp, bottom = 16.dp)
-            .windowInsetsPadding(
-                WindowInsets.navigationBars.only(WindowInsetsSides.Bottom)
-            ),
+            .padding(top = 24.dp)
+            .paddingBottomWithInsets(withNavBar = 16.dp, withoutNavBar = 24.dp),
     ) {
         Column(
             modifier = Modifier.weight(1f)

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/settings/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/settings/SettingsScreen.kt
@@ -75,7 +75,7 @@ fun SettingsScreen(
                 contentPadding = PaddingValues(
                     start = 16.dp,
                     end = 16.dp,
-                    bottom = navBarBottomPadding + 16.dp,
+                    bottom = navBarBottomPadding + 24.dp,
                 ),
                 modifier = Modifier.widthIn(max = AdaptiveUtil.MAX_FULL_SCREEN_WIDTH)
                     .fillMaxHeight()

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/util/PaddingUtil.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/util/PaddingUtil.kt
@@ -1,0 +1,52 @@
+package org.noiseplanet.noisecapture.util
+
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Utility modifier for bottom padding to provide different padding values based on the type of
+ * bottom navigation bar used by the device. If the device uses "modern" mobile navigation with a
+ * "bottom pill" (i.e. most borderless phones or tablets), it will apply the [withNavBar] value,
+ * plus bottom navigation bar insets. Otherwise (on desktop, older iPhones or "old school" android
+ * navigation with buttons), apply the [withoutNavBar] value.
+ *
+ * @param withNavBar Value applied for modern navigation bars, on top of the nav bar insets.
+ *                   Defaults to `0.dp`.
+ * @param withoutNavBar Value applied when no navigation bar that goes over content.
+ *                      By default, equals to `withNavBar`.
+ */
+@Composable
+fun Modifier.paddingBottomWithInsets(
+    withNavBar: Dp = 0.dp,
+    withoutNavBar: Dp = withNavBar,
+): Modifier {
+    // Calculate the bottom navigation bar padding in dp
+    val bottomNavBarHeight = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+
+    return if (bottomNavBarHeight == 0.dp) {
+        // If the nav bar doesn't go over content (i.e. buttons Android nav bar, desktop, old iPhones),
+        // return the padding value "without nav bar".
+        this.padding(bottom = withoutNavBar)
+    } else {
+        // Otherwise, return the padding value "with nav bar", plus the insets of the nav bar itself.
+        this.padding(bottom = withNavBar + bottomNavBarHeight)
+    }
+}
+
+
+/**
+ * Utility modifier to apply only top navigation bar window insets with shorter syntax.
+ */
+@Composable
+fun Modifier.navigationBarInsetsTop(): Modifier = this.windowInsetsPadding(
+    WindowInsets.navigationBars.only(WindowInsetsSides.Top)
+)


### PR DESCRIPTION
# Description

Added a utility modifier to provide different padding values based on the type of bottom navigation bar:

- On phones and tablets with "bottom pill" like navigation bar (i.e. most borderless phones and tablets), provide a smaller padding value because the navigation bar already provides spacing from the bottom of the screen
- On desktop (no bottom navigation) or android with buttons nav bar (old school navigation), provide larger padding values because there is no spacing already provided by the nav bar

## Changes

- Added a custom modifier to provide A or B padding value based on the type of bottom nav bar
- Use this custom modifier in all places where bottom padding was applied relative to the bottom of the screen

## Linked issues

- #210 

## Remaining TODOs

I tested this on smartphone, tablet emulator and web. There might still be some spots with regressions due to the change of padding handling but if so, I'll fix those in later PRs.

Globally, this shouldn't be a noticeable change from a user perspective. Only saves repeating the same verbose modifier configuration everywhere.

## Checklist

- [x] Code compiles correctly on all platforms
- [x] All pre-existing tests are passing
- [ ] If needed, new tests have been added
- [ ] Extended the README / documentation if necessary
- [x] Added code has been documented
