### PR TITLE
Feature/adaptive font size

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -15,6 +15,11 @@
     <string name="home_map_section_header">Community measurements</string>
     <string name="home_map_browse_button">Browse</string>
 
+    <string name="home_statistics_title">Statistics</string>
+    <!-- TODO: Use localisation that supports plurals -->
+    <string name="home_statistics_recordings_count">recordings</string>
+    <string name="home_statistics_total">total</string>
+
 
     <!--  Sound level meter  -->
     <string name="sound_level_meter_current_dba">Current dB(A)</string>

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/spl/LAeqMetricsView.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/spl/LAeqMetricsView.kt
@@ -84,7 +84,7 @@ fun LAeqMetricsView(
                     maxLines = 1,
                     autoSize = TextAutoSize.StepBased(
                         minFontSize = 16.sp,
-                        maxFontSize = 20.sp,
+                        maxFontSize = 18.sp,
                         stepSize = 0.25.sp,
                     )
                 )

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/home/HomeRecentMeasurementView.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/home/HomeRecentMeasurementView.kt
@@ -16,6 +16,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
@@ -67,9 +68,11 @@ fun HomeRecentMeasurementView(
                 }
             }
             .padding(top = 12.dp, bottom = 12.dp, start = 12.dp)
+            .height(IntrinsicSize.Min)
     ) {
         Row(
             horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier.fillMaxWidth()
         ) {
             Text(
@@ -95,7 +98,7 @@ fun HomeRecentMeasurementView(
         measurement?.let {
             LAeqMetricsView(
                 it.laeqMetrics,
-                modifier = Modifier.padding(top = 8.dp)
+                modifier = Modifier.padding(top = 4.dp)
                     .height(IntrinsicSize.Max)
             )
         }

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/home/LastMeasurementsView.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/home/LastMeasurementsView.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -83,14 +82,14 @@ private fun LastMeasurementsViewContentReady(
         return
     }
 
-    Column(modifier = modifier.fillMaxHeight().animateContentSize()) {
+    Column(modifier = modifier.animateContentSize()) {
         ListSectionHeader(
             title = Res.string.home_last_measurements_section_header,
         )
 
         Row(
             horizontalArrangement = Arrangement.spacedBy(4.dp),
-            modifier = Modifier.height(IntrinsicSize.Min)
+            modifier = Modifier.height(IntrinsicSize.Max)
                 .fillMaxWidth()
         ) {
             Column(
@@ -100,7 +99,6 @@ private fun LastMeasurementsViewContentReady(
                         color = MaterialTheme.colorScheme.surfaceContainer,
                         shape = MaterialTheme.shapes.medium,
                     )
-                    .fillMaxHeight()
                     .padding(16.dp)
             ) {
                 Text(
@@ -131,15 +129,14 @@ private fun LastMeasurementsViewContentReady(
             FlowRow(
                 maxItemsInEachRow = 2,
                 maxLines = 2,
-                modifier = Modifier.weight(1f),
+                modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(16.dp),
-                verticalArrangement = Arrangement.SpaceBetween
             ) {
                 viewState.lastMeasurementIds.forEach { measurementId ->
                     HomeRecentMeasurementView(
                         measurementId = measurementId,
                         onClick = onClickMeasurement,
-                        modifier = Modifier.weight(1f)
+                        modifier = Modifier.weight(1f),
                     )
                 }
             }

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/home/LastMeasurementsView.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/home/LastMeasurementsView.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
@@ -23,10 +24,15 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import noisecapture.composeapp.generated.resources.Res
 import noisecapture.composeapp.generated.resources.home_last_measurements_section_header
+import noisecapture.composeapp.generated.resources.home_statistics_recordings_count
+import noisecapture.composeapp.generated.resources.home_statistics_title
+import noisecapture.composeapp.generated.resources.home_statistics_total
+import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
 import org.noiseplanet.noisecapture.model.dao.Measurement
 import org.noiseplanet.noisecapture.ui.components.ListSectionHeader
@@ -62,6 +68,7 @@ fun LastMeasurementsView(
 }
 
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun LastMeasurementsViewContentReady(
     viewState: LastMeasurementsViewModel.ViewState.ContentReady,
@@ -97,14 +104,20 @@ private fun LastMeasurementsViewContentReady(
                     .padding(16.dp)
             ) {
                 Text(
-                    text = "Statistics",
+                    text = stringResource(Res.string.home_statistics_title),
                     style = MaterialTheme.typography.titleMedium.copy(
-                        color = MaterialTheme.colorScheme.onSecondaryContainer
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
                     ),
                 )
 
-                StatisticsElement(viewState.measurementsCount.toString(), "recordings")
-                StatisticsElement(viewState.totalDuration, "${viewState.durationUnit} total")
+                StatisticsElement(
+                    viewState.measurementsCount.toString(),
+                    stringResource(Res.string.home_statistics_recordings_count)
+                )
+                StatisticsElement(
+                    viewState.totalDuration,
+                    "${viewState.durationUnit} ${stringResource(Res.string.home_statistics_total)}"
+                )
 
                 Spacer(modifier = Modifier.weight(1f))
 
@@ -173,6 +186,8 @@ private fun StatisticsElement(
         Text(
             text = label,
             style = statisticsLabelStyle,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
             modifier = Modifier.alignByBaseline()
         )
     }

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/recording/RecordingPager.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/recording/RecordingPager.kt
@@ -6,16 +6,18 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.foundation.text.TextAutoSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SecondaryTabRow
 import androidx.compose.material3.Tab
-import androidx.compose.material3.Text
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.window.core.layout.WindowSizeClass
 import kotlinx.coroutines.launch
 import noisecapture.composeapp.generated.resources.Res
@@ -78,7 +80,17 @@ fun RecordingPager(
         ) {
             tabs.toList().forEachIndexed { index, (_, label) ->
                 Tab(
-                    text = { Text(label) },
+                    text = {
+                        BasicText(
+                            text = label,
+                            maxLines = 1,
+                            autoSize = TextAutoSize.StepBased(
+                                minFontSize = 12.sp,
+                                maxFontSize = 16.sp,
+                                stepSize = 0.25.sp,
+                            )
+                        )
+                    },
                     selected = pagerState.currentPage == index,
                     onClick = {
                         animationScope.launch {

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/recording/plot/spectrum/SpectrumPlotViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/recording/plot/spectrum/SpectrumPlotViewModel.kt
@@ -63,10 +63,11 @@ class SpectrumPlotViewModel : ViewModel(), KoinComponent {
                         label = "${tickValue.toInt()} dB"
                     )
                 },
-                yTicks = frequencies.map { freq ->
+                yTicks = frequencies.mapIndexed { index, freq ->
+                    // Only show labels on 1 out of 3 frequency bands
                     AxisTick(
                         value = freq.toDouble(),
-                        label = freq.toFrequencyString(),
+                        label = if ((index + 2) % 3 == 0) freq.toFrequencyString() else "",
                     )
                 },
                 showYTickMarks = false,

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/theme/Theme.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/theme/Theme.kt
@@ -7,6 +7,9 @@ import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
+import kotlin.math.min
 
 private val lightColorScheme = lightColorScheme(
     primary = PrimaryLight,
@@ -86,20 +89,29 @@ private val darkColorScheme = darkColorScheme(
     surfaceDim = SurfaceDimDark,
 )
 
-private val NCRippleConfiguration = RippleConfiguration(color = OnSurfaceVariantLight)
-
 
 @Composable
 fun AppTheme(
     darkTheme: Boolean = false, // TODO: Enable dark theme when color scheme will be consistent
     content: @Composable() () -> Unit,
 ) {
+    val rippleConfiguration = RippleConfiguration(color = OnSurfaceVariantLight)
+
+    // Limit device font scaling to 130% to avoid layout breaks while keeping accessibility
+    val density = Density(
+        density = LocalDensity.current.density,
+        fontScale = min(LocalDensity.current.fontScale, 1.3f)
+    )
+
     val colorScheme = when {
         darkTheme -> darkColorScheme
         else -> lightColorScheme
     }
 
-    CompositionLocalProvider(LocalRippleConfiguration provides NCRippleConfiguration) {
+    CompositionLocalProvider(
+        LocalRippleConfiguration provides rippleConfiguration,
+        LocalDensity provides density
+    ) {
         MaterialTheme(
             colorScheme = colorScheme,
             typography = notoSansTypography(),


### PR DESCRIPTION
# Description

Fixes layout issues related to device font size increase accessibility settings

## Changes

- Limit the scaling of the font to 130% as a compromise between keeping accessibility features available while still limiting the impact on the layout
- Restrict some `Text` composables to stick to only one line and adapt font size dynamically where needed
- Reduce the number of Y axis ticks on Spectrum plot

## Linked issues

- #214 
- #180 

## Remaining TODOs

There might still be some places where layout need to be adapted to fit on smaller devices, but I'll pick them up in later PRs when discovered

## Checklist

- [x] Code compiles correctly on all platforms
- [x] All pre-existing tests are passing
- [ ] If needed, new tests have been added
- [ ] Extended the README / documentation if necessary
- [x] Added code has been documented
