### PR TITLE
Fix/share sheet ios 18

### DIFF
--- a/androidApp/src/main/kotlin/org/noiseplanet/noisecapture/MainActivity.kt
+++ b/androidApp/src/main/kotlin/org/noiseplanet/noisecapture/MainActivity.kt
@@ -38,7 +38,7 @@ class MainActivity : ComponentActivity() {
     private lateinit var permissionService: PermissionService
     private lateinit var logger: Logger
 
-    private lateinit var filePickerEventBus: FilePickerEventBus
+    private lateinit var filePickerEventBus: AndroidFilePickerEventBus
     private var filePickerIntentLauncher: ActivityResultLauncher<Intent>? = null
 
     private val scope = CoroutineScope(Dispatchers.Main)

--- a/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/AndroidFilePickerEventBus.kt
+++ b/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/AndroidFilePickerEventBus.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.flow.asSharedFlow
 import java.io.File
 
 
-class FilePickerEventBus {
+class AndroidFilePickerEventBus {
 
     // - Properties
 

--- a/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/PlatformModule.kt
+++ b/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/PlatformModule.kt
@@ -66,7 +66,7 @@ val platformModule: Module = module {
     }
 
     single {
-        FilePickerEventBus()
+        AndroidFilePickerEventBus()
     }
 
     factory<AudioPlayer> { (filePath: String) ->

--- a/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/services/storage/AndroidFileSystemService.kt
+++ b/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/services/storage/AndroidFileSystemService.kt
@@ -5,8 +5,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
+import org.noiseplanet.noisecapture.AndroidFilePickerEventBus
 import org.noiseplanet.noisecapture.FilePickerEvent
-import org.noiseplanet.noisecapture.FilePickerEventBus
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
@@ -18,7 +18,7 @@ class AndroidFileSystemService : FileSystemService, KoinComponent {
     // - Properties
 
     private val context: Context by inject()
-    private val filePickerEventBus: FilePickerEventBus by inject()
+    private val filePickerEventBus: AndroidFilePickerEventBus by inject()
 
 
     // - Public functions

--- a/composeApp/src/iosMain/kotlin/MainViewController.kt
+++ b/composeApp/src/iosMain/kotlin/MainViewController.kt
@@ -1,17 +1,76 @@
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.uikit.LocalUIViewController
 import androidx.compose.ui.window.ComposeUIViewController
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.cinterop.ExperimentalForeignApi
+import org.koin.compose.koinInject
 import org.noiseplanet.noisecapture.initKoin
 import org.noiseplanet.noisecapture.platformModule
+import org.noiseplanet.noisecapture.util.FilePickerEvent
+import org.noiseplanet.noisecapture.util.IOSFilePickerEventBus
+import platform.UIKit.UIDocumentInteractionController
+import platform.UIKit.UIDocumentInteractionControllerDelegateProtocol
+import platform.darwin.NSObject
 
 /**
  * iOS application entry point
  */
+@OptIn(ExperimentalForeignApi::class)
 @Suppress("FunctionNaming")
 fun MainViewController() = ComposeUIViewController {
+
+    // - DI
 
     initKoin(
         additionalModules = listOf(
             platformModule
         )
     )
+
+
+    // - Properties
+
+    // Listen for file picker events and present view controller accordingly.
+    val eventBus: IOSFilePickerEventBus = koinInject()
+    val event: FilePickerEvent? by eventBus.events.collectAsStateWithLifecycle()
+
+    // Hold a reference to the ViewController and its delegate while it is being presented
+    var documentInteractionController: UIDocumentInteractionController?
+    var documentInteractionDelegate: UIDocumentInteractionControllerDelegate?
+
+    event?.let { event ->
+        val viewController = LocalUIViewController.current
+        // Create and configure document interaction controller
+        documentInteractionDelegate = UIDocumentInteractionControllerDelegate {
+            // Drop reference to document interaction controller
+            documentInteractionController = null
+            event.onDismiss()
+        }
+
+        documentInteractionController = UIDocumentInteractionController
+            .interactionControllerWithURL(event.fileUrl)
+        documentInteractionController?.delegate = documentInteractionDelegate
+        documentInteractionController?.presentOptionsMenuFromRect(
+            rect = viewController.view.bounds,
+            inView = viewController.view,
+            animated = true
+        )
+    }
+
+
+    // - Entry point
+
     App()
+}
+
+
+private class UIDocumentInteractionControllerDelegate(
+    private val onDismiss: () -> Unit,
+) : NSObject(), UIDocumentInteractionControllerDelegateProtocol {
+
+    override fun documentInteractionControllerDidDismissOptionsMenu(
+        controller: UIDocumentInteractionController,
+    ) {
+        onDismiss()
+    }
 }

--- a/composeApp/src/iosMain/kotlin/org/noiseplanet/noisecapture/PlatformModule.kt
+++ b/composeApp/src/iosMain/kotlin/org/noiseplanet/noisecapture/PlatformModule.kt
@@ -18,6 +18,7 @@ import org.noiseplanet.noisecapture.services.location.IOSUserLocationProvider
 import org.noiseplanet.noisecapture.services.location.UserLocationProvider
 import org.noiseplanet.noisecapture.services.storage.FileSystemService
 import org.noiseplanet.noisecapture.services.storage.IOSFileSystemService
+import org.noiseplanet.noisecapture.util.IOSFilePickerEventBus
 import platform.Foundation.NSBundle
 
 /**
@@ -55,6 +56,10 @@ val platformModule: Module = module {
 
     single<FileSystemService> {
         IOSFileSystemService()
+    }
+
+    single<IOSFilePickerEventBus> {
+        IOSFilePickerEventBus()
     }
 
     factory<AudioPlayer> { (filePath: String) ->

--- a/composeApp/src/iosMain/kotlin/org/noiseplanet/noisecapture/services/storage/IOSFileSystemService.kt
+++ b/composeApp/src/iosMain/kotlin/org/noiseplanet/noisecapture/services/storage/IOSFileSystemService.kt
@@ -3,8 +3,13 @@ package org.noiseplanet.noisecapture.services.storage
 import kotlinx.cinterop.BetaInteropApi
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.ptr
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
 import org.noiseplanet.noisecapture.log.Logger
+import org.noiseplanet.noisecapture.util.FilePickerEvent
+import org.noiseplanet.noisecapture.util.IOSFilePickerEventBus
 import org.noiseplanet.noisecapture.util.injectLogger
 import org.noiseplanet.noisecapture.util.runCatchingNSError
 import platform.Foundation.NSApplicationSupportDirectory
@@ -13,13 +18,8 @@ import platform.Foundation.NSFileCoordinatorReadingForUploading
 import platform.Foundation.NSFileManager
 import platform.Foundation.NSFileSize
 import platform.Foundation.NSURL
-import platform.Foundation.NSURLTypeIdentifierKey
 import platform.Foundation.NSUserDomainMask
 import platform.Foundation.temporaryDirectory
-import platform.UIKit.UIApplication
-import platform.UIKit.UIDocumentInteractionController
-import platform.UIKit.UIDocumentInteractionControllerDelegateProtocol
-import platform.darwin.NSObject
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 
@@ -30,9 +30,8 @@ class IOSFileSystemService : FileSystemService, KoinComponent {
     // - Properties
 
     private val logger: Logger by injectLogger()
+    private val filePickerEventBus: IOSFilePickerEventBus by inject()
 
-    private var documentInteractionController: UIDocumentInteractionController? = null
-    private var documentInteractionDelegate: UIDocumentInteractionControllerDelegate? = null
     private val fileManager: NSFileManager = NSFileManager.defaultManager
 
 
@@ -64,7 +63,9 @@ class IOSFileSystemService : FileSystemService, KoinComponent {
         val absoluteUrl = getAbsolutePath(fileUri) ?: return
         val fileUrl = NSURL.fileURLWithPath(absoluteUrl)
 
-        downloadFileAtUrl(fileUrl)
+        withContext(Dispatchers.Main) {
+            downloadFileAtUrl(fileUrl)
+        }
     }
 
     override suspend fun downloadFiles(fileUris: List<String>, archiveName: String) {
@@ -89,49 +90,27 @@ class IOSFileSystemService : FileSystemService, KoinComponent {
     // - Private functions
 
     /**
-     * Downloads the file at the given URL through [UIDocumentInteractionController].
+     * Downloads the file at the given URL through [IOSFilePickerEventBus].
      *
      * @param fileUrl [NSURL] pointing to the file to download.
      * @param deleteAfterUse If true, delete the file once picker is dismissed
      */
-    private fun downloadFileAtUrl(fileUrl: NSURL, deleteAfterUse: Boolean = false) {
-        // Create and configure document interaction controller
-        documentInteractionController = UIDocumentInteractionController
-            .interactionControllerWithURL(fileUrl)
-
-        documentInteractionDelegate = UIDocumentInteractionControllerDelegate(
-            onDismiss = {
-                // Drop reference to interaction controller
-                documentInteractionController = null
-                // If needed, delete the file
-                if (deleteAfterUse) {
-                    runCatchingNSError { nsError ->
-                        fileManager.removeItemAtURL(fileUrl, nsError.ptr)
-                    }.onFailure {
-                        logger.error("Error while deleting file at url $fileUrl")
+    private suspend fun downloadFileAtUrl(fileUrl: NSURL, deleteAfterUse: Boolean = false) {
+        filePickerEventBus.emitEvent(
+            FilePickerEvent(
+                fileUrl = fileUrl,
+                onDismiss = {
+                    // If needed, delete the file
+                    if (deleteAfterUse) {
+                        runCatchingNSError { nsError ->
+                            fileManager.removeItemAtURL(fileUrl, nsError.ptr)
+                        }.onFailure {
+                            logger.error("Error while deleting file at url $fileUrl")
+                        }
                     }
                 }
-            }
-        )
-
-        // Get resource type identifier from URL, or default to "public.data"
-        val uti = runCatchingNSError { nsError ->
-            fileUrl.resourceValuesForKeys(listOf(NSURLTypeIdentifierKey), nsError.ptr)
-                ?.get(NSURLTypeIdentifierKey) as? String?
-                ?: "public.data"
-        }.getOrNull()
-
-        documentInteractionController?.UTI = uti
-        documentInteractionController?.name = fileUrl.lastPathComponent
-        documentInteractionController?.delegate = documentInteractionDelegate
-
-        UIApplication.sharedApplication.keyWindow?.rootViewController?.view?.let { view ->
-            documentInteractionController?.presentOptionsMenuFromRect(
-                rect = view.bounds,
-                inView = view,
-                animated = true,
             )
-        }
+        )
     }
 
     /**
@@ -217,17 +196,5 @@ class IOSFileSystemService : FileSystemService, KoinComponent {
         }
 
         return zipUrl
-    }
-}
-
-
-private class UIDocumentInteractionControllerDelegate(
-    private val onDismiss: () -> Unit,
-) : NSObject(), UIDocumentInteractionControllerDelegateProtocol {
-
-    override fun documentInteractionControllerDidDismissOptionsMenu(
-        controller: UIDocumentInteractionController,
-    ) {
-        onDismiss()
     }
 }

--- a/composeApp/src/iosMain/kotlin/org/noiseplanet/noisecapture/util/IOSFilePickerEventBus.kt
+++ b/composeApp/src/iosMain/kotlin/org/noiseplanet/noisecapture/util/IOSFilePickerEventBus.kt
@@ -1,0 +1,41 @@
+package org.noiseplanet.noisecapture.util
+
+import MainViewController
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import platform.Foundation.NSURL
+import platform.UIKit.UIDocumentInteractionController
+
+
+/**
+ * Event bus used to pass down file download events to the host [MainViewController]
+ * so that it can build and present the [UIDocumentInteractionController] accordingly.
+ */
+class IOSFilePickerEventBus {
+
+    // - Properties
+
+    private val _events = MutableStateFlow<FilePickerEvent?>(null)
+    val events = _events.asStateFlow()
+
+
+    // - Public functions
+
+    /**
+     * Notify subscribers that a new file picker event is available.
+     */
+    suspend fun emitEvent(event: FilePickerEvent) {
+        _events.emit(event)
+    }
+}
+
+/**
+ * A file picker event
+ *
+ * @param fileUrl URL of the file to download
+ * @param onDismiss Optional callback that will be triggered when dismissing the view controller.
+ */
+data class FilePickerEvent(
+    val fileUrl: NSURL,
+    val onDismiss: () -> Unit = {},
+)


### PR DESCRIPTION
# Description

Fixes the file download modal on iOS <26.

## Changes

Instead of presenting the `UIDocumentInteractionViewController` from `UIApplication.sharedApplication.keyWindow.rootViewController`, pass down the download event through an event bus that is subscribed in `MainViewController`, and there present the interaction controller using `LocalUIViewController.current` as anchor.

For the sake of consistency and clarity, rename `FilePickerEventBus` in `androidMain` to `AndroidFilePickerEventBus`

## Linked issues

- #237 

## Remaining TODOs

N/A

## Checklist

- [x] Code compiles correctly on all platforms
- [x] All pre-existing tests are passing
- [ ] If needed, new tests have been added
- [ ] Extended the README / documentation if necessary
- [x] Added code has been documented
