### PR TITLE
Fix/ios permission settings

### DIFF
--- a/composeApp/src/iosMain/kotlin/org/noiseplanet/noisecapture/permission/delegate/AudioRecordPermissionDelegate.kt
+++ b/composeApp/src/iosMain/kotlin/org/noiseplanet/noisecapture/permission/delegate/AudioRecordPermissionDelegate.kt
@@ -5,11 +5,13 @@ import kotlinx.coroutines.flow.StateFlow
 import org.koin.core.component.KoinComponent
 import org.noiseplanet.noisecapture.log.Logger
 import org.noiseplanet.noisecapture.permission.PermissionState
-import org.noiseplanet.noisecapture.permission.util.openNSUrl
+import org.noiseplanet.noisecapture.permission.util.openURL
 import org.noiseplanet.noisecapture.util.injectLogger
 import platform.AVFAudio.AVAudioSession
 import platform.AVFAudio.AVAudioSessionRecordPermissionDenied
 import platform.AVFAudio.AVAudioSessionRecordPermissionGranted
+import platform.UIKit.UIApplication
+import platform.UIKit.UIApplicationOpenSettingsURLString
 
 
 internal class AudioRecordPermissionDelegate : PermissionDelegate, KoinComponent {
@@ -48,6 +50,8 @@ internal class AudioRecordPermissionDelegate : PermissionDelegate, KoinComponent
     override fun canOpenSettings(): Boolean = true
 
     override fun openSettingPage() {
-        openNSUrl("App-prefs:Privacy&path=MICROPHONE")
+        UIApplication.sharedApplication.openURL(UIApplicationOpenSettingsURLString) { _, error ->
+            error?.let { logger.error(it) }
+        }
     }
 }

--- a/composeApp/src/iosMain/kotlin/org/noiseplanet/noisecapture/permission/delegate/LocationBackgroundPermissionDelegate.kt
+++ b/composeApp/src/iosMain/kotlin/org/noiseplanet/noisecapture/permission/delegate/LocationBackgroundPermissionDelegate.kt
@@ -7,18 +7,24 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
+import org.noiseplanet.noisecapture.log.Logger
 import org.noiseplanet.noisecapture.permission.LocationManager
 import org.noiseplanet.noisecapture.permission.PermissionState
-import org.noiseplanet.noisecapture.permission.util.openNSUrl
+import org.noiseplanet.noisecapture.permission.util.openURL
+import org.noiseplanet.noisecapture.util.injectLogger
 import org.noiseplanet.noisecapture.util.stateInWhileSubscribed
 import platform.CoreLocation.kCLAuthorizationStatusAuthorizedAlways
 import platform.CoreLocation.kCLAuthorizationStatusAuthorizedWhenInUse
 import platform.CoreLocation.kCLAuthorizationStatusDenied
 import platform.CoreLocation.kCLAuthorizationStatusRestricted
+import platform.UIKit.UIApplication
+import platform.UIKit.UIApplicationOpenSettingsURLString
 
 internal class LocationBackgroundPermissionDelegate : PermissionDelegate, KoinComponent {
 
     // - Properties
+
+    private val logger: Logger by injectLogger()
 
     private val locationManager: LocationManager by inject()
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -63,6 +69,8 @@ internal class LocationBackgroundPermissionDelegate : PermissionDelegate, KoinCo
     override fun canOpenSettings(): Boolean = true
 
     override fun openSettingPage() {
-        openNSUrl("App-Prefs:Privacy&path=LOCATION")
+        UIApplication.sharedApplication.openURL(UIApplicationOpenSettingsURLString) { _, error ->
+            error?.let { logger.error(it) }
+        }
     }
 }

--- a/composeApp/src/iosMain/kotlin/org/noiseplanet/noisecapture/permission/delegate/LocationForegroundPermissionDelegate.kt
+++ b/composeApp/src/iosMain/kotlin/org/noiseplanet/noisecapture/permission/delegate/LocationForegroundPermissionDelegate.kt
@@ -7,18 +7,24 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
+import org.noiseplanet.noisecapture.log.Logger
 import org.noiseplanet.noisecapture.permission.LocationManager
 import org.noiseplanet.noisecapture.permission.PermissionState
-import org.noiseplanet.noisecapture.permission.util.openNSUrl
+import org.noiseplanet.noisecapture.permission.util.openURL
+import org.noiseplanet.noisecapture.util.injectLogger
 import org.noiseplanet.noisecapture.util.stateInWhileSubscribed
 import platform.CoreLocation.kCLAuthorizationStatusAuthorizedAlways
 import platform.CoreLocation.kCLAuthorizationStatusAuthorizedWhenInUse
 import platform.CoreLocation.kCLAuthorizationStatusDenied
 import platform.CoreLocation.kCLAuthorizationStatusRestricted
+import platform.UIKit.UIApplication
+import platform.UIKit.UIApplicationOpenSettingsURLString
 
 internal class LocationForegroundPermissionDelegate : PermissionDelegate, KoinComponent {
 
     // - Properties
+
+    private val logger: Logger by injectLogger()
 
     private val locationManager: LocationManager by inject()
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -63,6 +69,8 @@ internal class LocationForegroundPermissionDelegate : PermissionDelegate, KoinCo
     override fun canOpenSettings(): Boolean = true
 
     override fun openSettingPage() {
-        openNSUrl("App-Prefs:Privacy&path=LOCATION")
+        UIApplication.sharedApplication.openURL(UIApplicationOpenSettingsURLString) { _, error ->
+            error?.let { logger.error(it) }
+        }
     }
 }

--- a/composeApp/src/iosMain/kotlin/org/noiseplanet/noisecapture/permission/delegate/LocationServicePermissionDelegate.kt
+++ b/composeApp/src/iosMain/kotlin/org/noiseplanet/noisecapture/permission/delegate/LocationServicePermissionDelegate.kt
@@ -4,13 +4,19 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
+import org.noiseplanet.noisecapture.log.Logger
 import org.noiseplanet.noisecapture.permission.LocationManager
 import org.noiseplanet.noisecapture.permission.PermissionState
-import org.noiseplanet.noisecapture.permission.util.openNSUrl
+import org.noiseplanet.noisecapture.permission.util.openURL
+import org.noiseplanet.noisecapture.util.injectLogger
+import platform.UIKit.UIApplication
+import platform.UIKit.UIApplicationOpenSettingsURLString
 
 internal class LocationServicePermissionDelegate : PermissionDelegate, KoinComponent {
 
     // - Properties
+
+    private val logger: Logger by injectLogger()
 
     private val locationManager: LocationManager by inject()
 
@@ -43,6 +49,8 @@ internal class LocationServicePermissionDelegate : PermissionDelegate, KoinCompo
     override fun canOpenSettings(): Boolean = true
 
     override fun openSettingPage() {
-        openNSUrl("App-Prefs:Privacy&path=LOCATION")
+        UIApplication.sharedApplication.openURL(UIApplicationOpenSettingsURLString) { _, error ->
+            error?.let { logger.error(it) }
+        }
     }
 }

--- a/composeApp/src/iosMain/kotlin/org/noiseplanet/noisecapture/permission/util/Extensions.kt
+++ b/composeApp/src/iosMain/kotlin/org/noiseplanet/noisecapture/permission/util/Extensions.kt
@@ -2,19 +2,27 @@ package org.noiseplanet.noisecapture.permission.util
 
 import platform.Foundation.NSURL
 import platform.UIKit.UIApplication
-import platform.UIKit.UIApplicationOpenSettingsURLString
 
-internal fun openNSUrl(string: String) {
-    val settingsUrl: NSURL = requireNotNull(NSURL.URLWithString(string)) {
-        throw CannotOpenSettingsException(string)
-    }
-    if (UIApplication.sharedApplication.canOpenURL(settingsUrl)) {
-        UIApplication.sharedApplication.openURL(settingsUrl)
-    } else {
-        throw CannotOpenSettingsException(string)
-    }
-}
+/**
+ * Safe wrapper for [UIApplication.openURL] using url string.
+ *
+ * @param urlString URL string
+ * @param completion Completion handler
+ */
+fun UIApplication.openURL(
+    urlString: String,
+    completion: (success: Boolean, error: String?) -> Unit,
+) {
+    val url = NSURL.URLWithString(urlString)
+        ?: return completion(false, "Invalid URL: $urlString")
 
-internal fun openAppSettingsPage() {
-    openNSUrl(UIApplicationOpenSettingsURLString)
+    if (!UIApplication.sharedApplication.canOpenURL(url)) {
+        return completion(false, "Cannot open URL: $urlString")
+    }
+    UIApplication.sharedApplication.openURL(
+        url = url,
+        options = emptyMap<Any?, Any>()
+    ) { success ->
+        completion(success, if (success) null else "Could not open URL: $urlString")
+    }
 }


### PR DESCRIPTION
# Description

Fixes the `Go to settings` button not opening the settings page in iOS 18+

## Changes

Use the new `UIApplication.openURL` method with completion handler: https://developer.apple.com/documentation/uikit/uiapplication/open(_:options:completionhandler:)

## Linked issues

- #228 

## Remaining TODOs

N/A

## Checklist

- [x] Code compiles correctly on all platforms
- [x] All pre-existing tests are passing
- [ ] If needed, new tests have been added
- [ ] Extended the README / documentation if necessary
- [x] Added code has been documented
