### PR TITLE
Fix/history order

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/history/HistoryItemView.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/history/HistoryItemView.kt
@@ -16,12 +16,14 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.format
 import kotlinx.datetime.toLocalDateTime
@@ -29,6 +31,8 @@ import nl.jacobras.humanreadable.HumanReadable
 import noisecapture.composeapp.generated.resources.Res
 import noisecapture.composeapp.generated.resources.measurement_no_description_placeholder
 import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.koinInject
+import org.koin.core.parameter.parametersOf
 import org.noiseplanet.noisecapture.model.dao.Measurement
 import org.noiseplanet.noisecapture.ui.components.spl.LAeqMetricsView
 import org.noiseplanet.noisecapture.util.DateUtil
@@ -40,13 +44,19 @@ import kotlin.time.Instant
 @OptIn(ExperimentalTime::class)
 @Composable
 fun HistoryItemView(
-    measurement: Measurement,
+    measurementId: String,
     onClick: (Measurement) -> Unit,
     isFirstInSection: Boolean,
     isLastInSection: Boolean,
     modifier: Modifier = Modifier,
 ) {
     // - Properties
+
+    val viewModel: HistoryItemViewModel = koinInject {
+        parametersOf(measurementId)
+    }
+
+    val measurement by viewModel.measurementFlow.collectAsStateWithLifecycle()
 
     val shape = MaterialTheme.shapes.medium
         .let {
@@ -59,58 +69,61 @@ fun HistoryItemView(
             }
         }
 
-    val instant = Instant.fromEpochMilliseconds(measurement.startTimestamp)
-    val localDateTime = instant.toLocalDateTime(TimeZone.currentSystemDefault())
-    val startTime = localDateTime.format(DateUtil.Format.MEASUREMENT_START_DATETIME)
-
 
     // - Layout
 
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = modifier.background(MaterialTheme.colorScheme.surface, shape)
-            .clip(shape)
-            .clickable { onClick(measurement) }
-            .padding(start = 16.dp, end = 0.dp, top = 16.dp, bottom = 16.dp)
-    ) {
-        Column(
-            modifier = Modifier.weight(1f)
+    measurement?.let { measurement ->
+
+        val instant = Instant.fromEpochMilliseconds(measurement.startTimestamp)
+        val localDateTime = instant.toLocalDateTime(TimeZone.currentSystemDefault())
+        val startTime = localDateTime.format(DateUtil.Format.MEASUREMENT_START_DATETIME)
+
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = modifier.background(MaterialTheme.colorScheme.surface, shape)
+                .clip(shape)
+                .clickable { onClick(measurement) }
+                .padding(start = 16.dp, end = 0.dp, top = 16.dp, bottom = 16.dp)
         ) {
-            Text(
-                text = startTime,
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onSurface,
-                fontWeight = FontWeight.SemiBold,
-            )
-            Text(
-                text = HumanReadable.duration(measurement.duration.milliseconds),
-                style = MaterialTheme.typography.bodySmall,
-            )
+            Column(
+                modifier = Modifier.weight(1f)
+            ) {
+                Text(
+                    text = startTime,
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Text(
+                    text = HumanReadable.duration(measurement.duration.milliseconds),
+                    style = MaterialTheme.typography.bodySmall,
+                )
 
-            Spacer(Modifier.height(8.dp))
+                Spacer(Modifier.height(8.dp))
 
-            Text(
-                // TODO: Get description from measurement
-                text = stringResource(Res.string.measurement_no_description_placeholder),
-                maxLines = 3,
-                overflow = TextOverflow.Ellipsis,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
+                Text(
+                    // TODO: Get description from measurement
+                    text = stringResource(Res.string.measurement_no_description_placeholder),
+                    maxLines = 3,
+                    overflow = TextOverflow.Ellipsis,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
 
-            Spacer(Modifier.height(8.dp))
+                Spacer(Modifier.height(8.dp))
 
-            LAeqMetricsView(
-                measurement.laeqMetrics,
-                modifier = Modifier.height(IntrinsicSize.Max)
+                LAeqMetricsView(
+                    measurement.laeqMetrics,
+                    modifier = Modifier.height(IntrinsicSize.Max)
+                )
+            }
+
+            Icon(
+                imageVector = Icons.Default.ChevronRight,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = 8.dp).size(20.dp),
             )
         }
-
-        Icon(
-            imageVector = Icons.Default.ChevronRight,
-            contentDescription = null,
-            tint = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(horizontal = 8.dp).size(20.dp),
-        )
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/history/HistoryItemViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/history/HistoryItemViewModel.kt
@@ -1,0 +1,21 @@
+package org.noiseplanet.noisecapture.ui.features.history
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.StateFlow
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import org.noiseplanet.noisecapture.model.dao.Measurement
+import org.noiseplanet.noisecapture.services.measurement.MeasurementService
+import org.noiseplanet.noisecapture.util.stateInWhileSubscribed
+
+class HistoryItemViewModel(measurementId: String) : ViewModel(), KoinComponent {
+
+    // - Properties
+
+    private val measurementService: MeasurementService by inject()
+
+    val measurementFlow: StateFlow<Measurement?> = measurementService
+        .getMeasurementFlow(measurementId)
+        .stateInWhileSubscribed(viewModelScope, initialValue = null)
+}

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/history/HistoryModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/history/HistoryModule.kt
@@ -1,7 +1,13 @@
 package org.noiseplanet.noisecapture.ui.features.history
 
 import org.koin.dsl.module
+import org.noiseplanet.noisecapture.log.Logger
 
 val historyModule = module {
 
+    factory { (measurementId: String) ->
+        val logger = get<Logger>()
+        logger.debug("VIEWMODEL FOR ID: $measurementId")
+        HistoryItemViewModel(measurementId)
+    }
 }

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/history/HistoryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/history/HistoryScreen.kt
@@ -27,8 +27,10 @@ import kotlinx.datetime.format.FormatStringsInDatetimeFormats
 import noisecapture.composeapp.generated.resources.Res
 import noisecapture.composeapp.generated.resources.history_empty_state_hint
 import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.koinInject
 import org.koin.compose.module.rememberKoinModules
 import org.koin.core.annotation.KoinExperimentalAPI
+import org.noiseplanet.noisecapture.log.Logger
 import org.noiseplanet.noisecapture.ui.navigation.router.HistoryRouter
 import org.noiseplanet.noisecapture.util.AdaptiveUtil
 import kotlin.time.ExperimentalTime
@@ -49,7 +51,8 @@ fun HistoryScreen(
 
     // - Properties
 
-    val measurements by viewModel.measurementsFlow.collectAsStateWithLifecycle()
+    val logger = koinInject<Logger>()
+    val measurementIds by viewModel.measurementIdsFlow.collectAsStateWithLifecycle()
 
 
     // - Layout
@@ -63,12 +66,17 @@ fun HistoryScreen(
                     .asPaddingValues(),
                 modifier = Modifier.widthIn(max = AdaptiveUtil.MAX_FULL_SCREEN_WIDTH)
             ) {
-                itemsIndexed(measurements) { index, measurement ->
+                itemsIndexed(
+                    items = measurementIds,
+                    key = { _, measurementId -> measurementId }
+                ) { index, measurementId ->
                     val isFirstInSection = index == 0
-                    val isLastInSection = index == measurements.size - 1
+                    val isLastInSection = index == measurementIds.size - 1
+
+                    logger.warning("MEASUREMENT ID: $measurementId")
 
                     HistoryItemView(
-                        measurement = measurement,
+                        measurementId = measurementId,
                         onClick = router::onClickMeasurement,
                         isFirstInSection = isFirstInSection,
                         isLastInSection = isLastInSection,
@@ -84,7 +92,7 @@ fun HistoryScreen(
                 }
             }
 
-            if (measurements.isEmpty()) {
+            if (measurementIds.isEmpty()) {
                 Text(
                     text = stringResource(Res.string.history_empty_state_hint),
                     textAlign = TextAlign.Center,

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/history/HistoryScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/history/HistoryScreenViewModel.kt
@@ -8,7 +8,6 @@ import noisecapture.composeapp.generated.resources.history_title
 import org.jetbrains.compose.resources.StringResource
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
-import org.noiseplanet.noisecapture.model.dao.Measurement
 import org.noiseplanet.noisecapture.services.measurement.MeasurementService
 import org.noiseplanet.noisecapture.ui.components.appbar.ScreenViewModel
 import org.noiseplanet.noisecapture.util.stateInWhileSubscribed
@@ -20,7 +19,7 @@ class HistoryScreenViewModel : ViewModel(), ScreenViewModel, KoinComponent {
 
     private val measurementService: MeasurementService by inject()
 
-    val measurementsFlow: StateFlow<List<Measurement>> = measurementService.getAllMeasurementsFlow()
+    val measurementIdsFlow: StateFlow<List<String>> = measurementService.getAllMeasurementIdsFlow()
         .stateInWhileSubscribed(
             scope = viewModelScope,
             initialValue = emptyList(),

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/history/HistoryScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/history/HistoryScreenViewModel.kt
@@ -3,6 +3,7 @@ package org.noiseplanet.noisecapture.ui.features.history
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
 import noisecapture.composeapp.generated.resources.Res
 import noisecapture.composeapp.generated.resources.history_title
 import org.jetbrains.compose.resources.StringResource
@@ -20,6 +21,10 @@ class HistoryScreenViewModel : ViewModel(), ScreenViewModel, KoinComponent {
     private val measurementService: MeasurementService by inject()
 
     val measurementIdsFlow: StateFlow<List<String>> = measurementService.getAllMeasurementIdsFlow()
+        .map {
+            // Most recent measurements comes first
+            it.reversed()
+        }
         .stateInWhileSubscribed(
             scope = viewModelScope,
             initialValue = emptyList(),


### PR DESCRIPTION
# Description

Show most recent measurement first in history

## Changes

- Reverse the order of measurements in history screen
- Read measurement from disk on demand and only use ids as index

## Linked issues

- #253 

## Remaining TODOs

N/A

## Checklist

- [x] Code compiles correctly on all platforms
- [x] All pre-existing tests are passing
- [ ] If needed, new tests have been added
- [ ] Extended the README / documentation if necessary
- [x] Added code has been documented
