### PR TITLE
Fix/history order

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -78,6 +78,7 @@
 
     <string name="details_audio_player_title">Recorded audio</string>
     <string name="details_audio_player_description">Listen to the audio that was recorded during your measurement.</string>
+    <string name="details_audio_player_disclaimer">This is for your ears only, audio recordings are never sent to our servers.</string>
 
     <string name="details_spl_time_plot_title">Noise level over time</string>
     <string name="details_spl_time_plot_description">Visualise the evolution of recorded noise level as a function of time.</string>

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/audioplayer/AudioPlayerView.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/audioplayer/AudioPlayerView.kt
@@ -18,11 +18,16 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import noisecapture.composeapp.generated.resources.Res
 import noisecapture.composeapp.generated.resources.details_audio_player_description
+import noisecapture.composeapp.generated.resources.details_audio_player_disclaimer
 import noisecapture.composeapp.generated.resources.details_audio_player_title
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
@@ -70,7 +75,13 @@ fun AudioPlayerView(
         )
 
         Text(
-            text = stringResource(Res.string.details_audio_player_description),
+            text = buildAnnotatedString {
+                append(stringResource(Res.string.details_audio_player_description))
+                withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
+                    // show disclaimer with bold font
+                    append(stringResource(Res.string.details_audio_player_disclaimer))
+                }
+            },
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/map/MapLegendView.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/map/MapLegendView.kt
@@ -33,9 +33,12 @@ fun MapLegendView(
 
     // - Properties
 
-    val items: Map<String, Color> = NoiseLevelColorRamp.palette.mapKeys { entry ->
-        ">= ${entry.key.toInt()} dB"
-    }
+    val items: List<Pair<String, Color>> = NoiseLevelColorRamp.palette.toList()
+        .filter { (level, _) -> level > 0 }
+        .sortedByDescending { (level, _) -> level }
+        .map { (level, color) ->
+            Pair(">= ${level.toInt()} dB", color)
+        }
 
     val cancelButtonViewModel = NCButtonViewModel(
         title = Res.string.cancel,

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/map/MapLegendView.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/map/MapLegendView.kt
@@ -33,12 +33,9 @@ fun MapLegendView(
 
     // - Properties
 
-    val items: List<Pair<String, Color>> = NoiseLevelColorRamp.palette.toList()
-        .filter { (level, _) -> level > 0 }
-        .sortedByDescending { (level, _) -> level }
-        .map { (level, color) ->
-            Pair(">= ${level.toInt()} dB", color)
-        }
+    val items: List<Pair<String, Color>> = NoiseLevelColorRamp.paletteAsLegendElements(
+        descendingOrder = true
+    )
 
     val cancelButtonViewModel = NCButtonViewModel(
         title = Res.string.cancel,

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/details/RnePlotView.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/details/RnePlotView.kt
@@ -53,15 +53,7 @@ fun RnePlotView(
     // - Properties
 
     var selectedSliceIndex: Int? by remember { mutableStateOf(null) }
-    val legendData = remember {
-        NoiseLevelColorRamp.palette.keys.mapIndexed { index, level ->
-            when (index) {
-                0 -> "<${rneData.keys.elementAt(index + 1).toInt()} dB(A)"
-                rneData.keys.size - 1 -> ">${level.toInt()} dB(A)"
-                else -> "${level.toInt()}-${rneData.keys.elementAt(index + 1).toInt()} dB(A)"
-            }
-        }.zip(NoiseLevelColorRamp.palette.values).toMap()
-    }
+    val legendData = remember { NoiseLevelColorRamp.paletteAsLegendElements() }
 
 
     // - Subviews
@@ -191,13 +183,11 @@ fun RnePlotView(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(16.dp)
             ) {
-                legendData.keys.chunked(6).forEach { chunk ->
+                legendData.chunked(6).forEach { chunk ->
                     Column {
-                        chunk.forEach { label ->
-                            legendData[label]?.let { color ->
-                                val index = legendData.keys.indexOf(label)
-                                LegendElement(color, label, index)
-                            }
+                        chunk.forEachIndexed { index, (label, color) ->
+                            val trueIndex = legendData.indexOfFirst { it.first == label }
+                            LegendElement(color, label, trueIndex)
                         }
                     }
                 }

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/theme/NoiseLevelColorRamp.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/theme/NoiseLevelColorRamp.kt
@@ -60,6 +60,7 @@ object NoiseLevelColorRamp {
      */
     val palette: Map<Double, Color> = mapOf(
         0.0 to level1,
+        30.0 to level1,
         35.0 to level2,
         40.0 to level3,
         45.0 to level4,
@@ -77,6 +78,7 @@ object NoiseLevelColorRamp {
      */
     val paletteDarker: Map<Double, Color> = mapOf(
         0.0 to level1Dark,
+        30.0 to level1Dark,
         35.0 to level2Dark,
         40.0 to level3Dark,
         45.0 to level4Dark,
@@ -94,6 +96,7 @@ object NoiseLevelColorRamp {
      */
     val paletteLighter: Map<Double, Color> = mapOf(
         0.0 to level1Light,
+        30.0 to level1Light,
         35.0 to level2Light,
         40.0 to level3Light,
         45.0 to level4Light,

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/theme/NoiseLevelColorRamp.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/theme/NoiseLevelColorRamp.kt
@@ -155,4 +155,33 @@ object NoiseLevelColorRamp {
             ?.value
             ?: Color.Black
     }
+
+    /**
+     * Returns a [label: color] legend representation of the given palette
+     *
+     * @param palette Target color palette
+     * @param descendingOrder If true, elements will be returned in descending order.
+     * @return Legend label to color representation
+     */
+    fun paletteAsLegendElements(
+        palette: Map<Double, Color> = NoiseLevelColorRamp.palette,
+        descendingOrder: Boolean = false,
+    ): List<Pair<String, Color>> {
+        val legendList = palette.filter { (level, _) -> level > 0 }.toList()
+
+        val legend = legendList.mapIndexed { index, (level, color) ->
+            val label = when (index) {
+                0 -> "<${level.toInt()} dB(A)"
+                legendList.lastIndex -> ">${level.toInt()} dB(A)"
+                else -> "${level.toInt()}-${legendList[index + 1].first.toInt()} dB(A)"
+            }
+            Pair(label, color)
+        }
+
+        return if (descendingOrder) {
+            legend.reversed()
+        } else {
+            legend
+        }
+    }
 }


### PR DESCRIPTION
# Description

Two small fixes to map legend:

- Show noise levels in descending order (highest level on top)
- Start legend at 30dB instead of 0

## Changes

- Reverse items order in noise map legend
- Add a 30dB color to noise palette and leave it out of legend, so that legend starts at 0dB 

## Linked issues

- #220 

## Remaining TODOs

N/A

## Checklist

- [x] Code compiles correctly on all platforms
- [x] All pre-existing tests are passing
- [ ] If needed, new tests have been added
- [ ] Extended the README / documentation if necessary
- [x] Added code has been documented
