### PR TITLE
Feature/wasm navigation urls

### DIFF
--- a/composeApp/src/commonMain/kotlin/App.kt
+++ b/composeApp/src/commonMain/kotlin/App.kt
@@ -1,5 +1,6 @@
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.NavController
 import org.koin.compose.koinInject
 import org.noiseplanet.noisecapture.ui.navigation.RootCoordinator
 import org.noiseplanet.noisecapture.ui.navigation.RootCoordinatorViewModel
@@ -7,13 +8,20 @@ import org.noiseplanet.noisecapture.ui.theme.AppTheme
 
 /**
  * Entry point of the Compose app.
+ *
+ * @param navController Root navigation controller. Can be overridden for platform specific customisation.
  */
 @Composable
 @Preview
-fun App() {
+fun App(
+    onNavHostReady: suspend (NavController) -> Unit = {},
+) {
     AppTheme {
         val coordinatorViewModel: RootCoordinatorViewModel = koinInject()
 
-        RootCoordinator(viewModel = coordinatorViewModel)
+        RootCoordinator(
+            viewModel = coordinatorViewModel,
+            onNavHostReady = onNavHostReady,
+        )
     }
 }

--- a/composeApp/src/commonMain/kotlin/Platform.kt
+++ b/composeApp/src/commonMain/kotlin/Platform.kt
@@ -54,4 +54,11 @@ interface Platform {
      */
     val navigationTransitions: NavigationTransitions
         get() = MobileNavigationTransitions
+
+    /**
+     * If true, show the back arrow button in app bar to navigate back.
+     * Defaults to `true`.
+     */
+    val showAppBarBackButton: Boolean
+        get() = true
 }

--- a/composeApp/src/commonMain/kotlin/Platform.kt
+++ b/composeApp/src/commonMain/kotlin/Platform.kt
@@ -1,6 +1,8 @@
 import androidx.compose.ui.graphics.ImageBitmapConfig
 import org.noiseplanet.noisecapture.model.dao.UserAgent
 import org.noiseplanet.noisecapture.permission.Permission
+import org.noiseplanet.noisecapture.ui.navigation.MobileNavigationTransitions
+import org.noiseplanet.noisecapture.ui.navigation.NavigationTransitions
 import org.noiseplanet.noisecapture.ui.navigation.RouteId
 import org.noiseplanet.noisecapture.ui.navigation.RouteIds
 
@@ -45,4 +47,11 @@ interface Platform {
      */
     val bitmapConfig: ImageBitmapConfig
         get() = ImageBitmapConfig.Rgb565
+
+    /**
+     * Describes the animations when navigating between screens.
+     * Defaults to [MobileNavigationTransitions].
+     */
+    val navigationTransitions: NavigationTransitions
+        get() = MobileNavigationTransitions
 }

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/appbar/AppBar.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/appbar/AppBar.kt
@@ -1,5 +1,6 @@
 package org.noiseplanet.noisecapture.ui.components.appbar
 
+import Platform
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
@@ -21,6 +22,7 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import noisecapture.composeapp.generated.resources.Res
 import noisecapture.composeapp.generated.resources.back_button
 import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.koinInject
 
 @Composable
 fun AppBar(
@@ -28,6 +30,8 @@ fun AppBar(
     modifier: Modifier = Modifier,
 ) {
     // - Properties
+
+    val platform: Platform = koinInject()
 
     val screenViewModel = appBarState.viewModel ?: return
     val actions by screenViewModel.actions.collectAsStateWithLifecycle()
@@ -52,7 +56,7 @@ fun AppBar(
             actionIconContentColor = MaterialTheme.colorScheme.onSurface,
         ),
         navigationIcon = {
-            if (canNavigateUp) {
+            if (canNavigateUp && platform.showAppBarBackButton) {
                 IconButton(onClick = {
                     if (screenViewModel.confirmPopBackStack()) {
                         appBarState.navController.navigateUp()

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/history/HistoryModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/history/HistoryModule.kt
@@ -1,13 +1,10 @@
 package org.noiseplanet.noisecapture.ui.features.history
 
 import org.koin.dsl.module
-import org.noiseplanet.noisecapture.log.Logger
 
 val historyModule = module {
 
     factory { (measurementId: String) ->
-        val logger = get<Logger>()
-        logger.debug("VIEWMODEL FOR ID: $measurementId")
         HistoryItemViewModel(measurementId)
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/history/HistoryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/history/HistoryScreen.kt
@@ -27,10 +27,8 @@ import kotlinx.datetime.format.FormatStringsInDatetimeFormats
 import noisecapture.composeapp.generated.resources.Res
 import noisecapture.composeapp.generated.resources.history_empty_state_hint
 import org.jetbrains.compose.resources.stringResource
-import org.koin.compose.koinInject
 import org.koin.compose.module.rememberKoinModules
 import org.koin.core.annotation.KoinExperimentalAPI
-import org.noiseplanet.noisecapture.log.Logger
 import org.noiseplanet.noisecapture.ui.navigation.router.HistoryRouter
 import org.noiseplanet.noisecapture.util.AdaptiveUtil
 import kotlin.time.ExperimentalTime
@@ -51,7 +49,6 @@ fun HistoryScreen(
 
     // - Properties
 
-    val logger = koinInject<Logger>()
     val measurementIds by viewModel.measurementIdsFlow.collectAsStateWithLifecycle()
 
 
@@ -72,8 +69,6 @@ fun HistoryScreen(
                 ) { index, measurementId ->
                     val isFirstInSection = index == 0
                     val isLastInSection = index == measurementIds.size - 1
-
-                    logger.warning("MEASUREMENT ID: $measurementId")
 
                     HistoryItemView(
                         measurementId = measurementId,

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/home/LastMeasurementsView.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/home/LastMeasurementsView.kt
@@ -1,7 +1,5 @@
 package org.noiseplanet.noisecapture.ui.features.home
 
-import androidx.compose.animation.Crossfade
-import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -53,16 +51,15 @@ fun LastMeasurementsView(
 
     // - Layout
 
-    Crossfade(viewState, modifier = modifier) { viewState ->
-        when (viewState) {
-            is LastMeasurementsViewModel.ViewState.Loading -> LastMeasurementsViewLoading()
+    when (viewState) {
+        is LastMeasurementsViewModel.ViewState.Loading -> LastMeasurementsViewLoading()
 
-            is LastMeasurementsViewModel.ViewState.ContentReady -> LastMeasurementsViewContentReady(
-                viewState,
-                onClickMeasurement = onClickMeasurement,
-                onClickOpenHistoryButton = onClickOpenHistoryButton,
-            )
-        }
+        is LastMeasurementsViewModel.ViewState.ContentReady -> LastMeasurementsViewContentReady(
+            viewState as LastMeasurementsViewModel.ViewState.ContentReady,
+            onClickMeasurement = onClickMeasurement,
+            onClickOpenHistoryButton = onClickOpenHistoryButton,
+            modifier = modifier,
+        )
     }
 }
 
@@ -81,7 +78,7 @@ private fun LastMeasurementsViewContentReady(
         return
     }
 
-    Column(modifier = modifier.animateContentSize()) {
+    Column(modifier = modifier) {
         ListSectionHeader(
             title = Res.string.home_last_measurements_section_header,
             modifier = Modifier.padding(start = 12.dp),

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/recording/RecordingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/recording/RecordingScreen.kt
@@ -95,6 +95,7 @@ fun RecordingScreen(
         lifecycleOwner.lifecycle.addObserver(observer)
 
         onDispose {
+            viewModel.endCurrentRecording()
             lifecycleOwner.lifecycle.removeObserver(observer)
         }
     }

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/navigation/NavigationManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/navigation/NavigationManager.kt
@@ -1,5 +1,6 @@
 package org.noiseplanet.noisecapture.ui.navigation
 
+import Platform
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -11,6 +12,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
+import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
 import org.noiseplanet.noisecapture.permission.Permission
@@ -43,13 +45,20 @@ fun NavigationManager(
     showPermissionPrompt: (Permission) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    // - Properties
+
+    val platform: Platform = koinInject()
+
+
+    // - Navigation graph
+
     NavHost(
         navController = navController,
         startDestination = HomeRoute(),
-        enterTransition = Transitions.enterTransition,
-        exitTransition = Transitions.exitTransition,
-        popEnterTransition = Transitions.popEnterTransition,
-        popExitTransition = Transitions.popExitTransition,
+        enterTransition = platform.navigationTransitions.enterTransition,
+        exitTransition = platform.navigationTransitions.exitTransition,
+        popEnterTransition = platform.navigationTransitions.popEnterTransition,
+        popExitTransition = platform.navigationTransitions.popExitTransition,
         modifier = modifier.fillMaxSize()
             .padding(top = innerPadding.calculateTopPadding())
             .background(MaterialTheme.colorScheme.surface)

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/navigation/RootCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/navigation/RootCoordinator.kt
@@ -3,10 +3,12 @@ package org.noiseplanet.noisecapture.ui.navigation
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.navigation.NavController
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.toRoute
@@ -25,24 +27,18 @@ import org.noiseplanet.noisecapture.ui.features.permission.RequestPermissionModa
 @Composable
 fun RootCoordinator(
     viewModel: RootCoordinatorViewModel,
+    onNavHostReady: suspend (NavController) -> Unit = {},
 ) {
 
     // - Properties
 
     val navController: NavHostController = rememberNavController()
-    val appBarState: AppBarState = rememberAppBarState(navController)
 
+    val appBarState: AppBarState = rememberAppBarState(navController)
     val lifecycleOwner: LifecycleOwner = LocalLifecycleOwner.current
 
 
     // - Lifecycle
-
-    navController.addOnDestinationChangedListener { navController, _, _ ->
-        // Triggered when navigating to a new screen or from another screen
-        navController.currentBackStackEntry?.toRoute<Route>()?.let {
-            viewModel.setCurrentRoute(it)
-        }
-    }
 
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
@@ -101,6 +97,17 @@ fun RootCoordinator(
                 viewModel.promptPermissionIfNeeded(permission)
             }
         )
+
+        // After navigation is created, subscribe to destination changes and notify listeners
+        LaunchedEffect(navController) {
+            navController.addOnDestinationChangedListener { navController, _, _ ->
+                // Triggered when navigating to a new screen or from another screen
+                navController.currentBackStackEntry?.toRoute<Route>()?.let {
+                    viewModel.setCurrentRoute(it)
+                }
+            }
+            onNavHostReady(navController)
+        }
 
         // If needed, prompt permission request to the user
         RequestPermissionModal(

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/navigation/Route.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/navigation/Route.kt
@@ -5,22 +5,19 @@ import kotlinx.serialization.Serializable
 
 /**
  * A unique route identifier, regardless of eventual route constructor parameters
- *
- * TODO: With current compose navigation library, using an enum for this property crashes on iOS.
- *       Check with later updates if we can use an enum instead.
  */
 object RouteIds {
 
-    const val HOME = "home"
-    const val RECORDING = "recording"
-    const val HISTORY = "history"
-    const val SETTINGS = "settings"
-    const val DETAILS = "details"
-    const val COMMUNITY_MAP = "community_map"
+    const val HOME: RouteId = "home"
+    const val RECORDING: RouteId = "recording"
+    const val HISTORY: RouteId = "history"
+    const val SETTINGS: RouteId = "settings"
+    const val DETAILS: RouteId = "details"
+    const val COMMUNITY_MAP: RouteId = "map"
 
     // Naming this route "DEBUG" breaks compilation on iOS because it gets interpreted as and
     // obj-C macro.
-    const val DEBUG_ROUTE = "debug"
+    const val DEBUG_ROUTE: RouteId = "debug"
 }
 typealias RouteId = String
 
@@ -35,7 +32,52 @@ typealias RouteId = String
 open class Route(
     val id: RouteId,
     val usesAudioSource: Boolean = false,
-)
+) {
+
+    // - Static constructor
+
+    companion object {
+
+        /**
+         * Builds a [Route] from URL path (e.g. `details/{id}`), if possible.
+         *
+         * @param urlPath URL path (e.g. `details/{id}`)
+         * @return Corresponding route, or null if couldn't match to any route.
+         */
+        fun fromUrlPath(urlPath: String): Route? {
+            val pathComponents = urlPath.split("/")
+            val routeId = pathComponents.firstOrNull() ?: return null
+
+            return when (routeId) {
+                RouteIds.HOME -> HomeRoute()
+                RouteIds.RECORDING -> RecordingRoute()
+                RouteIds.HISTORY -> HistoryRoute()
+                RouteIds.SETTINGS -> SettingsRoute()
+                RouteIds.COMMUNITY_MAP -> CommunityMapRoute()
+                RouteIds.DEBUG_ROUTE -> DebugRoute()
+
+                RouteIds.DETAILS -> {
+                    val measurementId = pathComponents.getOrNull(1) ?: return null
+                    DetailsRoute(
+                        measurementId = measurementId,
+                        parentRouteId = RouteIds.HOME, // TODO: Can this work?
+                    )
+                }
+
+                else -> null
+            }
+        }
+    }
+
+
+    /**
+     * Represents this route as a URL path (e.g. details/242?parameter=true).
+     * By default, only returns the route's id.
+     */
+    open fun toUrlPath(): String {
+        return id
+    }
+}
 
 
 // - Routes
@@ -56,7 +98,12 @@ class SettingsRoute : Route(id = RouteIds.SETTINGS)
 class DetailsRoute(
     val measurementId: String,
     val parentRouteId: String,
-) : Route(id = RouteIds.DETAILS)
+) : Route(id = RouteIds.DETAILS) {
+
+    override fun toUrlPath(): String {
+        return "$id/$measurementId"
+    }
+}
 
 @Serializable
 class CommunityMapRoute : Route(id = RouteIds.COMMUNITY_MAP)

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/navigation/Transitions.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/navigation/Transitions.kt
@@ -11,37 +11,81 @@ private typealias TransitionCallback<TransitionType> =
     (AnimatedContentTransitionScope<NavBackStackEntry>.() -> TransitionType)
 
 /**
- * Transition animations to be used across this app.
+ * Describes navigation transitions when going from one screen to another.
+ * Wrapped into an interface so that platform can implement specific navigation behaviour.
  */
-object Transitions {
+interface NavigationTransitions {
+
+    /**
+     * Transition for the new entering screen
+     */
+    val enterTransition: TransitionCallback<EnterTransition>
+
+    /**
+     * Transition for the old exiting screen
+     */
+    val exitTransition: TransitionCallback<ExitTransition>
+
+    /**
+     * Transition for the parent screen coming in when popping back stack
+     */
+    val popEnterTransition: TransitionCallback<EnterTransition>
+
+    /**
+     * Transition for the current screen exiting when popping back stack
+     */
+    val popExitTransition: TransitionCallback<ExitTransition>
+}
+
+/**
+ * On mobile targets, use slide in/out transitions between screens to emphasize the idea of
+ * navigation stack to the end user. New screens will come from the right hand side of the screen.
+ */
+object MobileNavigationTransitions : NavigationTransitions {
 
     /**
      * Duration of screen transitions in milliseconds
      */
     private const val TRANSITION_DURATION = 300
 
-    val enterTransition: TransitionCallback<EnterTransition> = {
+    override val enterTransition: TransitionCallback<EnterTransition> = {
         slideIntoContainer(
             AnimatedContentTransitionScope.SlideDirection.Start,
             tween(easing = FastOutSlowInEasing, durationMillis = TRANSITION_DURATION)
         )
     }
-    val exitTransition: TransitionCallback<ExitTransition> = {
+
+    override val exitTransition: TransitionCallback<ExitTransition> = {
         slideOutOfContainer(
             AnimatedContentTransitionScope.SlideDirection.Start,
             tween(easing = FastOutSlowInEasing, durationMillis = TRANSITION_DURATION)
         )
     }
-    val popEnterTransition: TransitionCallback<EnterTransition> = {
+
+    override val popEnterTransition: TransitionCallback<EnterTransition> = {
         slideIntoContainer(
             AnimatedContentTransitionScope.SlideDirection.End,
             tween(easing = FastOutSlowInEasing, durationMillis = TRANSITION_DURATION)
         )
     }
-    val popExitTransition: TransitionCallback<ExitTransition> = {
+
+    override val popExitTransition: TransitionCallback<ExitTransition> = {
         slideOutOfContainer(
             AnimatedContentTransitionScope.SlideDirection.End,
             tween(easing = FastOutSlowInEasing, durationMillis = TRANSITION_DURATION)
         )
     }
+}
+
+/**
+ * On web, no transitions are expected between screens, new screens entering just replace the
+ * currently displayed ones.
+ */
+object WebNavigationTransitions : NavigationTransitions {
+
+    override val enterTransition: TransitionCallback<EnterTransition> = { EnterTransition.None }
+    override val exitTransition: TransitionCallback<ExitTransition> = { ExitTransition.None }
+    override val popEnterTransition: TransitionCallback<EnterTransition> = { EnterTransition.None }
+    override val popExitTransition: TransitionCallback<ExitTransition> = { ExitTransition.None }
+
 }

--- a/composeApp/src/wasmJsMain/kotlin/Platform.wasmjs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/Platform.wasmjs.kt
@@ -1,8 +1,10 @@
 import org.noiseplanet.noisecapture.interop.navigator
 import org.noiseplanet.noisecapture.model.dao.UserAgent
 import org.noiseplanet.noisecapture.permission.Permission
+import org.noiseplanet.noisecapture.ui.navigation.NavigationTransitions
 import org.noiseplanet.noisecapture.ui.navigation.RouteId
 import org.noiseplanet.noisecapture.ui.navigation.RouteIds
+import org.noiseplanet.noisecapture.ui.navigation.WebNavigationTransitions
 
 class WasmJSPlatform : Platform {
 
@@ -34,4 +36,7 @@ class WasmJSPlatform : Platform {
                 Permission.LOCATION_BACKGROUND,
             )
         )
+
+    override val navigationTransitions: NavigationTransitions
+        get() = WebNavigationTransitions
 }

--- a/composeApp/src/wasmJsMain/kotlin/Platform.wasmjs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/Platform.wasmjs.kt
@@ -39,4 +39,8 @@ class WasmJSPlatform : Platform {
 
     override val navigationTransitions: NavigationTransitions
         get() = WebNavigationTransitions
+
+    // On web, rely on the browser's backward/forward buttons for navigation
+    override val showAppBarBackButton: Boolean
+        get() = false
 }

--- a/composeApp/src/wasmJsMain/kotlin/main.kt
+++ b/composeApp/src/wasmJsMain/kotlin/main.kt
@@ -1,18 +1,65 @@
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.window.ComposeViewport
+import androidx.navigation.ExperimentalBrowserHistoryApi
+import androidx.navigation.bindToBrowserNavigation
+import androidx.navigation.toRoute
 import kotlinx.browser.document
+import kotlinx.browser.window
 import org.noiseplanet.noisecapture.initKoin
 import org.noiseplanet.noisecapture.platformModule
+import org.noiseplanet.noisecapture.ui.navigation.DetailsRoute
+import org.noiseplanet.noisecapture.ui.navigation.HomeRoute
+import org.noiseplanet.noisecapture.ui.navigation.Route
 
-@OptIn(ExperimentalComposeUiApi::class)
+@OptIn(
+    ExperimentalComposeUiApi::class,
+    ExperimentalBrowserHistoryApi::class,
+    ExperimentalWasmJsInterop::class
+)
 fun main() {
 
     ComposeViewport(document.body!!) {
+
+        // - DI
+
         initKoin(
             additionalModules = listOf(
                 platformModule
             )
         )
-        App()
+
+
+        // - Navigation
+
+        App(onNavHostReady = { navController ->
+            // Get the manually entered route
+            val initRouteId = window.location.hash.substringAfter('#', "")
+            Route.fromUrlPath(initRouteId)?.let { route ->
+                // Do nothing, app starts on home route anyway
+                if (route is HomeRoute) return@let
+                navController.navigate(route)
+            }
+
+            navController.bindToBrowserNavigation { entry ->
+                val routeName = entry.destination.route.orEmpty()
+                val path = when {
+                    // Identifies the route using its serial descriptor.
+                    // For route with custom parameter, we need to deserialize the corresponding
+                    // route class in order to access route parameters.
+                    routeName.startsWith(DetailsRoute.serializer().descriptor.serialName) -> {
+                        entry.toRoute<DetailsRoute>().toUrlPath()
+                    }
+
+                    else -> {
+                        // Otherwise, use default route path which only consists of route id.
+                        entry.toRoute<Route>().toUrlPath()
+                    }
+                }
+                // This string must always start with the `#` character to keep
+                // the processing at the front end
+                // See: https://kotlinlang.org/docs/multiplatform/compose-navigation-routing.html
+                "#$path"
+            }
+        })
     }
 }


### PR DESCRIPTION
# Description

Binds the app's navigation to the browser's navigation stack. Effectively, this means the URL in the browser's bar changes based on the page the user is on, and backward/forward navigation can be done using the browser's backward/forward arrows (like you would do for a regular website)

## Changes

- Bind `NavHostController` to the browser's navigation as described [here](https://kotlinlang.org/docs/multiplatform/compose-navigation-routing.html#support-for-browser-navigation-in-web-apps)
- Override the default navigation transitions (slide in/out) for web targets to give a more "web-like" feel to the app.
- Hide the app bar's back arrow for web targets (navigation should be done using browser controls, like for any website)
- Since `BackHandler` doesn't catch browser navigation events, if user tries to leave the recording screen while a measurement is ongoing, end it and save the results quietly (I couldn't manage to show the confirmation dialog like it would on mobile targets).

## Linked issues

- #115 

## Remaining TODOs

Perhaps the new back handler implementation (see #232) will allow us to catch browser navigation events.

## Checklist

- [x] Code compiles correctly on all platforms
- [x] All pre-existing tests are passing
- [ ] If needed, new tests have been added
- [ ] Extended the README / documentation if necessary
- [x] Added code has been documented
