### PR TITLE
Feature/deprecated back handler

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -92,11 +92,11 @@ kotlin {
             implementation(libs.compose.ui)
             implementation(libs.compose.components.resources)
             implementation(libs.compose.ui.tooling.preview)
-
-            implementation(libs.androidx.navigation.compose)
-            implementation(libs.androidx.viewmodel.compose)
-            implementation(libs.androidx.runtime.compose)
-            implementation(libs.androidx.backhandler.compose)
+            implementation(libs.compose.ui.backhandler)
+            implementation(libs.compose.navigation)
+            implementation(libs.compose.navigationevent)
+            implementation(libs.compose.lifecycle.viewmodel)
+            implementation(libs.compose.lifecycle.runtime)
 
             implementation(libs.koin.core)
             implementation(libs.koin.compose)

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/permission/RequestPermissionModal.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/permission/RequestPermissionModal.kt
@@ -26,11 +26,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.backhandler.BackHandler
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigationevent.NavigationEventInfo
+import androidx.navigationevent.compose.NavigationBackHandler
+import androidx.navigationevent.compose.rememberNavigationEventState
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
@@ -94,13 +96,17 @@ fun RequestPermissionModal(
         },
     ) {
         // Handle back press or back gesture.
-        BackHandler {
-            if (viewState.isRequired) {
-                onGoBackButtonPress()
-            } else {
-                onSkipButtonPress(viewState.permission)
+        NavigationBackHandler(
+            state = rememberNavigationEventState(NavigationEventInfo.None),
+            isBackEnabled = true,
+            onBackCompleted = {
+                if (viewState.isRequired) {
+                    onGoBackButtonPress()
+                } else {
+                    onSkipButtonPress(viewState.permission)
+                }
             }
-        }
+        )
 
         Column(
             verticalArrangement = Arrangement.spacedBy(4.dp),

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/recording/RecordingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/recording/RecordingScreen.kt
@@ -23,13 +23,15 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.backhandler.BackHandler
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.navigationevent.NavigationEventInfo
+import androidx.navigationevent.compose.NavigationBackHandler
+import androidx.navigationevent.compose.rememberNavigationEventState
 import androidx.window.core.layout.WindowSizeClass
 import org.koin.compose.module.rememberKoinModules
 import org.koin.core.annotation.KoinExperimentalAPI
@@ -105,9 +107,15 @@ fun RecordingScreen(
     Surface(
         color = MaterialTheme.colorScheme.surface,
     ) {
-        BackHandler {
-            viewModel.confirmPopBackStack()
-        }
+        NavigationBackHandler(
+            state = rememberNavigationEventState(NavigationEventInfo.None),
+            isBackEnabled = true,
+            onBackCompleted = {
+                if (viewModel.confirmPopBackStack()) {
+                    router.popBackStack()
+                }
+            }
+        )
 
         if (sizeClass.minWidthDp < WindowSizeClass.WIDTH_DP_MEDIUM_LOWER_BOUND) {
             RecordingScreenCompact(viewModel)

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/recording/RecordingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/recording/RecordingScreen.kt
@@ -128,7 +128,10 @@ fun RecordingScreen(
 
     if (showEndRecordingConfirmationDialog) {
         EndRecordingConfirmationDialog(
-            onDismissRequest = { showEndRecordingConfirmationDialog = false },
+            onDismissRequest = {
+                viewModel.shouldOpenDetailsOnceDone = true
+                showEndRecordingConfirmationDialog = false
+            },
             onConfirm = {
                 viewModel.endCurrentRecording()
             },

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,9 +10,10 @@ androidx-preference = "1.2.1"
 build-konfig-gradle-plugin = "0.17.1"
 # compose-* library versions must be set according to the libraries table on the corresponding
 # compose verison release page (e.g. https://github.com/JetBrains/compose-multiplatform/releases/tag/v1.10.0)
-compose = "1.10.0"
-compose-androidx-lifecycle = "2.10.0-alpha06"
-compose-androidx-navigation = "2.9.1"
+compose = "1.10.1"
+compose-lifecycle = "2.10.0-alpha06"
+compose-navigation = "2.9.2"
+compose-navigationevent = "1.0.1"
 compose-material = "1.7.3"
 compose-material3 = "1.10.0-alpha05"
 compose-material3-adaptive = "1.3.0-alpha02"
@@ -20,9 +21,9 @@ coroutines = "1.10.2"
 detekt = "1.23.8"
 google-play-services-android-location = "21.3.0"
 human-readable = "1.12.3"
-koala-plot = "0.10.4"
+koala-plot = "0.11.0"
 koin = "4.1.1"
-kotlin = "2.3.0"
+kotlin = "2.3.10"
 kotlinx-datetime = "0.7.1"
 kotlinx-serialization = "1.10.0"
 kstore = "1.0.0"
@@ -33,20 +34,21 @@ zipjs = "2.8.15"
 
 [libraries]
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "androidx-activity-compose" }
-androidx-backhandler-compose = { group = "org.jetbrains.compose.ui", name = "ui-backhandler", version.ref = "compose" }
-androidx-navigation-compose = { group = "org.jetbrains.androidx.navigation", name = "navigation-compose", version.ref = "compose-androidx-navigation" }
 androidx-preference = { group = "androidx.preference", name = "preference-ktx", version.ref = "androidx-preference" }
-androidx-runtime-compose = { group = "org.jetbrains.androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "compose-androidx-lifecycle" }
-androidx-viewmodel-compose = { group = "org.jetbrains.androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "compose-androidx-lifecycle" }
 buildkonfig-gradle-plugin = { group = "com.codingfeline.buildkonfig", name = "buildkonfig-gradle-plugin", version.ref = "build-konfig-gradle-plugin" }
+compose-navigation = { group = "org.jetbrains.androidx.navigation", name = "navigation-compose", version.ref = "compose-navigation" }
+compose-navigationevent = { group = "org.jetbrains.androidx.navigationevent", name = "navigationevent-compose", version.ref = "compose-navigationevent" }
 compose-components-resources = { group = "org.jetbrains.compose.components", name = "components-resources", version.ref = "compose" }
 compose-foundation = { group = "org.jetbrains.compose.foundation", name = "foundation", version.ref = "compose" }
+compose-lifecycle-runtime = { group = "org.jetbrains.androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "compose-lifecycle" }
+compose-lifecycle-viewmodel = { group = "org.jetbrains.androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "compose-lifecycle" }
 compose-material-icons-extended = { group = "org.jetbrains.compose.material", name = "material-icons-extended", version.ref = "compose-material" }
 compose-material3 = { group = "org.jetbrains.compose.material3", name = "material3", version.ref = "compose-material3" }
 compose-material3-adaptive = { group = "org.jetbrains.compose.material3.adaptive", name = "adaptive", version.ref = "compose-material3-adaptive" }
 compose-material3-adaptive-layout = { group = "org.jetbrains.compose.material3.adaptive", name = "adaptive-layout", version.ref = "compose-material3-adaptive" }
 compose-runtime = { group = "org.jetbrains.compose.runtime", name = "runtime", version.ref = "compose" }
 compose-ui = { group = "org.jetbrains.compose.ui", name = "ui", version.ref = "compose" }
+compose-ui-backhandler = { group = "org.jetbrains.compose.ui", name = "ui-backhandler", version.ref = "compose" }
 compose-ui-tooling = { group = "org.jetbrains.compose.ui", name = "ui-tooling", version.ref = "compose" }
 compose-ui-tooling-preview = { group = "org.jetbrains.compose.ui", name = "ui-tooling-preview", version.ref = "compose" }
 google-play-services-android-location = { group = "com.google.android.gms", name = "play-services-location", version.ref = "google-play-services-android-location" }


### PR DESCRIPTION
# Description

Replace usages of deprecated `BackHandler` with the new `NavigationBackHandler`

For details, see: https://kotlinlang.org/docs/multiplatform/whats-new-compose-110.html#deprecated-predictivebackhandler

## Changes

- Add `org.jetbrains.androidx.navigationevent:navigationevent-compose` dependency
- Replace usages of `BackHandler` with `NavigationBackHandler`
- Fix a bug where if the user tried to end a measurement by going back while recording, then cancels the confirmation popup, and ends the measurement with the stop button, it would go back to the home screen instead of opening the measurement details page.
- Update dependencies

## Linked issues

- #232 

## Remaining TODOs

N/A

## Checklist

- [x] Code compiles correctly on all platforms
- [x] All pre-existing tests are passing
- [ ] If needed, new tests have been added
- [ ] Extended the README / documentation if necessary
- [x] Added code has been documented
