### PR TITLE
Feature/calibration tips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - WasmJS: Browser URL bar now shows the current page URL. Navigation on web is now done through
   browser backward/forward actions instead of in-app back buttons. (#257)
 - Added changelog to better keep track of changes (#263)
-- Microphone calibration from reference device (#266)
+- Microphone calibration from reference device (#266, #275)
 
 ### Fixed
 

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -253,6 +253,17 @@
     <string name="calibration_frequencies_whole_spectrum_description">All frequency bands</string>
     <string name="calibration_start_button_title">Start calibration</string>
 
+    <string name="calibration_tips_environment_title">Environment conditions</string>
+    <string name="calibration_tips_environment_distance">Microphone should be placed at least two meters away from the sound source.</string>
+    <string name="calibration_tips_environment_corners">If calibration is done indoors, avoid being in one of the room corners.</string>
+    <string name="calibration_tips_environment_direction">Microphone should not be facing the sound source.</string>
+    <string name="calibration_tips_environment_quiet">Avoid making noises close to the microphones.</string>
+    <string name="calibration_tips_environment_placement">Put the phone on a table instead of holding it in your hand.</string>
+    <string name="calibration_tips_source_title">Sound source</string>
+    <string name="calibration_tips_source_nature">Try using one of the following sound sources: pink noise, environmental noise (like cars passing in a street), or as fallback, people talking in the distance.</string>
+    <string name="calibration_tips_reference_title">Reference device</string>
+    <string name="calibration_tips_reference_preferences">Use one of the following reference devices, in order of preference: a sound level meter, a smartphone with a calibrated external microphone, a smartphone with a calibrated internal microphone, small moving objects which sound levels are known to you.</string>
+
     <string name="calibration_countdown_label">Calibration will start in</string>
     <string name="calibration_recording_countdown_label">Measuring...</string>
     <string name="calibration_recording_current_average">Current average</string>

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/calibration/CalibrationConfigView.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/calibration/CalibrationConfigView.kt
@@ -1,5 +1,6 @@
 package org.noiseplanet.noisecapture.ui.features.calibration
 
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -12,6 +13,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowRight
 import androidx.compose.material.icons.filled.ArrowDropDown
@@ -41,6 +44,7 @@ import noisecapture.composeapp.generated.resources.calibration_frequencies_selec
 import noisecapture.composeapp.generated.resources.calibration_frequencies_whole_spectrum_description
 import noisecapture.composeapp.generated.resources.calibration_from_reference_intro_description
 import noisecapture.composeapp.generated.resources.calibration_from_reference_intro_title
+import noisecapture.composeapp.generated.resources.calibration_from_reference_tips_title
 import noisecapture.composeapp.generated.resources.calibration_microphone_current_gain
 import noisecapture.composeapp.generated.resources.calibration_microphone_last_calibrated
 import noisecapture.composeapp.generated.resources.calibration_microphone_not_calibrated
@@ -79,6 +83,8 @@ fun CalibrationConfigView(
     val currentCalibrationProfile: MicrophoneCalibrationProfile? by viewModel.currentCalibrationProfile
         .collectAsStateWithLifecycle()
 
+    val scrollState: ScrollState = rememberScrollState()
+
 
     // - Layout
 
@@ -90,12 +96,13 @@ fun CalibrationConfigView(
             Column(
                 verticalArrangement = Arrangement.spacedBy(16.dp),
                 horizontalAlignment = Alignment.CenterHorizontally,
-                modifier = Modifier.widthIn(max = AdaptiveUtil.MAX_FULL_SCREEN_WIDTH)
+                modifier = Modifier.verticalScroll(scrollState)
+                    .widthIn(max = AdaptiveUtil.MAX_FULL_SCREEN_WIDTH)
                     .padding(16.dp)
                     .paddingBottomWithInsets()
             ) {
                 // Introduction section
-                Column {
+                Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
                     Text(
                         text = stringResource(Res.string.calibration_from_reference_intro_title),
                         style = MaterialTheme.typography.titleMedium,
@@ -106,7 +113,15 @@ fun CalibrationConfigView(
                     )
                 }
 
-                // TODO: Add tips section
+                // Tips section
+                Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                    Text(
+                        text = stringResource(Res.string.calibration_from_reference_tips_title),
+                        style = MaterialTheme.typography.titleMedium,
+                    )
+                    CalibrationTipsView()
+                }
+
 
                 // Microphone select section
                 Column(

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/calibration/CalibrationScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/calibration/CalibrationScreenViewModel.kt
@@ -160,16 +160,17 @@ class CalibrationScreenViewModel : ViewModel(), ScreenViewModel, KoinComponent {
 
     fun onReferenceValueChange(newReferenceValue: Double?) {
         val state = viewState.value as ViewState.Results
+        val difference = newReferenceValue?.let {
+            (it - state.measuredValue).roundTo(1)
+        }
         val suggestedGain = newReferenceValue?.let {
             (it - (state.measuredValue - state.currentGain)).roundTo(1)
         }
-        val isWarning = (suggestedGain?.absoluteValue ?: 0.0) >= CALIBRATION_WARNING_THRESHOLD
+        val isWarning = (difference?.absoluteValue ?: 0.0) >= CALIBRATION_WARNING_THRESHOLD
 
         _viewState.tryEmit(
             state.copy(
-                difference = newReferenceValue?.let {
-                    (it - state.measuredValue).roundTo(1)
-                },
+                difference = difference,
                 suggestedGain = suggestedGain,
                 isWarning = isWarning,
             )

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/calibration/CalibrationTipsView.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/calibration/CalibrationTipsView.kt
@@ -1,0 +1,165 @@
+package org.noiseplanet.noisecapture.ui.features.calibration
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.ArrowDropUp
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import noisecapture.composeapp.generated.resources.Res
+import noisecapture.composeapp.generated.resources.calibration_tips_environment_corners
+import noisecapture.composeapp.generated.resources.calibration_tips_environment_direction
+import noisecapture.composeapp.generated.resources.calibration_tips_environment_distance
+import noisecapture.composeapp.generated.resources.calibration_tips_environment_placement
+import noisecapture.composeapp.generated.resources.calibration_tips_environment_quiet
+import noisecapture.composeapp.generated.resources.calibration_tips_environment_title
+import noisecapture.composeapp.generated.resources.calibration_tips_reference_preferences
+import noisecapture.composeapp.generated.resources.calibration_tips_reference_title
+import noisecapture.composeapp.generated.resources.calibration_tips_source_nature
+import noisecapture.composeapp.generated.resources.calibration_tips_source_title
+import org.jetbrains.compose.resources.StringResource
+import org.jetbrains.compose.resources.stringResource
+import org.noiseplanet.noisecapture.ui.theme.NoiseLevelColorRamp
+
+
+@Composable
+fun CalibrationTipsView(
+    modifier: Modifier = Modifier,
+) {
+    // - Properties
+
+    val tips = listOf(
+        CalibrationTips(
+            title = Res.string.calibration_tips_environment_title,
+            tips = listOf(
+                Res.string.calibration_tips_environment_distance,
+                Res.string.calibration_tips_environment_corners,
+                Res.string.calibration_tips_environment_direction,
+                Res.string.calibration_tips_environment_quiet,
+                Res.string.calibration_tips_environment_placement,
+            )
+        ),
+        CalibrationTips(
+            title = Res.string.calibration_tips_source_title,
+            tips = listOf(Res.string.calibration_tips_source_nature)
+        ),
+        CalibrationTips(
+            title = Res.string.calibration_tips_reference_title,
+            tips = listOf(Res.string.calibration_tips_reference_preferences)
+        ),
+    )
+
+
+    // - Layout
+
+    Column(
+        modifier = modifier.clip(shape = MaterialTheme.shapes.medium)
+    ) {
+        for (tipsItem in tips) {
+            ExpandableSection(title = stringResource(tipsItem.title)) {
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                    modifier = Modifier.padding(12.dp)
+                ) {
+                    for (tip in tipsItem.tips) {
+                        Text(
+                            text = stringResource(tip),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = NoiseLevelColorRamp.level1Dark,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+
+@Composable
+private fun ExpandableSectionTitle(
+    isExpanded: Boolean,
+    title: String,
+    modifier: Modifier = Modifier,
+) {
+    // - Properties
+
+    val icon = if (isExpanded) Icons.Default.ArrowDropUp else Icons.Default.ArrowDropDown
+
+
+    // - Layout
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = modifier.background(NoiseLevelColorRamp.level1Light).padding(12.dp)
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = NoiseLevelColorRamp.level1Dark,
+            modifier = Modifier.size(24.dp)
+        )
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleMedium,
+            color = NoiseLevelColorRamp.level1Dark,
+            modifier = Modifier.weight(1f)
+        )
+    }
+}
+
+
+@Composable
+private fun ExpandableSection(
+    title: String,
+    initiallyExpanded: Boolean = false,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    // - Properties
+
+    var isExpanded by rememberSaveable { mutableStateOf(initiallyExpanded) }
+
+
+    // - Layout
+
+    Column(
+        modifier = modifier
+            .clickable { isExpanded = !isExpanded }
+            .fillMaxWidth()
+    ) {
+        ExpandableSectionTitle(isExpanded = isExpanded, title = title)
+
+        AnimatedVisibility(
+            modifier = Modifier.background(MaterialTheme.colorScheme.surfaceContainer)
+                .fillMaxWidth(),
+            visible = isExpanded,
+        ) {
+            content()
+        }
+    }
+}
+
+
+data class CalibrationTips(
+    val title: StringResource,
+    val tips: List<StringResource>,
+)

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/navigation/router/DetailsRouter.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/navigation/router/DetailsRouter.kt
@@ -2,6 +2,9 @@ package org.noiseplanet.noisecapture.ui.navigation.router
 
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavHostController
+import androidx.navigation.toRoute
+import org.noiseplanet.noisecapture.ui.navigation.Route
+import org.noiseplanet.noisecapture.ui.navigation.RouteIds
 
 /**
  * Handles navigating to new screens after user takes actions on the details screen.
@@ -14,6 +17,11 @@ class DetailsRouter(
     // - Public functions
 
     fun onMeasurementDeleted() {
+        if (navController.currentBackStackEntry?.toRoute<Route>()?.id != RouteIds.DETAILS) {
+            // Measurement deleted callback might trigger twice in some cases, so before popping
+            // backstack, assert that we are still on the details screen.
+            return
+        }
         navController.popBackStack()
     }
 }


### PR DESCRIPTION
# Description

Adds tips for a good calibration on the calibration config screen:

<img width="374" height="760" alt="image" src="https://github.com/user-attachments/assets/cc17dfc5-d627-4bde-b5d4-f5adbf695767" />

## Changes

I went for an expandable sections approach instead of a horizontal carousel since the content size of each section greatly varies.

## Linked issues

- #267 

## Remaining TODOs

The content of each section and the number of sections can be updated later on if needed.

## Checklist

- [x] Code compiles correctly on all platforms
- [x] All pre-existing tests are passing
- [ ] If needed, new tests have been added
- [ ] Extended the README / documentation if necessary
- [x] Added code has been documented
