### PR TITLE
Feature/shared version code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Updated icons set (#277)
+- Ensure that version numbers are in sync between platforms (#281)
 
 ## [0.8.0] - 2026-03-04
 

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.gradle.internal.extensions.core.extra
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -21,17 +22,17 @@ kotlin {
         implementation(libs.koin.android)
     }
 
-    val appNamespace: String by project
     val appPackageName: String by project
-    val appVersionCode: String by project
-    val appVersionName: String by project
+    val androidAppId: String by project
+    val appVersionName = rootProject.extra.get("versionName") as String
+    val appVersionCode = rootProject.extra.get("versionCode") as String
 
     android {
-        namespace = appNamespace
+        namespace = appPackageName
         compileSdk = libs.versions.android.compileSdk.get().toInt()
 
         defaultConfig {
-            applicationId = appPackageName
+            applicationId = androidAppId
             minSdk = libs.versions.android.minSdk.get().toInt()
             targetSdk = libs.versions.android.targetSdk.get().toInt()
             versionCode = appVersionCode.toInt()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 import io.gitlab.arturbosch.detekt.Detekt
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import java.util.Properties
 
 plugins {
     alias(libs.plugins.androidApplication) apply false
@@ -31,3 +32,13 @@ allprojects {
         basePath = rootDir.absolutePath
     }
 }
+
+// Read values from version.properties and set them in rootProject.extra to be retrieved in submodules
+val versionProperties = Properties().apply {
+    val versionFile = project.rootProject.file("version.properties")
+    if (versionFile.exists()) {
+        load(versionFile.inputStream())
+    }
+}
+extra.set("versionName", versionProperties.getProperty("versionName"))
+extra.set("versionCode", versionProperties.getProperty("versionCode"))

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.codingfeline.buildkonfig.compiler.FieldSpec.Type
+import org.gradle.internal.extensions.core.extra
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
@@ -18,16 +19,17 @@ plugins {
     alias(libs.plugins.buildKonfigGradlePlugin)
 }
 
-val appNamespace: String by project
-val appVersionCode: String by project
-val appVersionName: String by project
 
 buildkonfig {
-    packageName = appNamespace
+    val appVersionName = rootProject.extra.get("versionName") as String
+    val appVersionCode = rootProject.extra.get("versionCode") as String
+    val appPackageName: String by project
+
+    packageName = appPackageName
 
     defaultConfigs {
         buildConfigField(Type.STRING, name = "versionName", value = appVersionName, const = true)
-        buildConfigField(Type.INT, name = "versionCode", value = appVersionCode)
+        buildConfigField(Type.INT, name = "versionCode", value = appVersionCode, const = true)
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,5 @@ kotlin.incremental.native=true
 org.jetbrains.compose.experimental.uikit.enabled=true
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 # NoiseCapture
-appNamespace=org.noiseplanet.noisecapture
-appPackageName=org.noiseplanet.noisecapturekmp
-appVersionName=0.8.0
-appVersionCode=11
+appPackageName=org.noiseplanet.noisecapture
+androidAppId=org.noiseplanet.noisecapturekmp

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -102,6 +102,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 7555FFA5242A565B00829871 /* Build configuration list for PBXNativeTarget "iosApp" */;
 			buildPhases = (
+				0E7F3F4A2FA0FEBC00D9C081 /* ShellScript */,
 				F36B1CEB2AD83DDC00CB74D5 /* Compile Kotlin Framework */,
 				7555FF77242A565900829871 /* Sources */,
 				B92378962B6B1156000C7307 /* Frameworks */,
@@ -168,6 +169,23 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		0E7F3F4A2FA0FEBC00D9C081 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Read version from version.properties\nVERSION_NAME=$(cat \"$SRCROOT/../version.properties\" | grep \"versionName\" | cut -d'=' -f2)\nVERSION_CODE=$(cat \"$SRCROOT/../version.properties\" | grep \"versionCode\" | cut -d'=' -f2)\n\n# Set Info.plist values\n/usr/libexec/PlistBuddy -c \"Set :CFBundleShortVersionString $VERSION_NAME\" \"$INFOPLIST_FILE\"\n/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $VERSION_CODE\" \"$INFOPLIST_FILE\"\n";
+		};
 		F36B1CEB2AD83DDC00CB74D5 /* Compile Kotlin Framework */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/version.properties
+++ b/version.properties
@@ -1,0 +1,5 @@
+# =========
+# Shared version name and version code to be used for both Android and iOS app to keep consistency.
+# =========
+versionName=0.8.0
+versionCode=11


### PR DESCRIPTION
# Description

Dynamically set version name and build number in Info.plist based on values set in `version.properties`. 

## Changes

This keeps all version numbers between apps in sync. `Info.plist` is updated using `Plistbuddy` when building the iOS app via a `Run script` phase in XCode's build phases.

## Linked issues

- #122 

## Remaining TODOs

N/A

## Checklist

- [x] Code compiles correctly on all platforms
- [x] All pre-existing tests are passing
- [ ] If needed, new tests have been added
- [ ] Extended the README / documentation if necessary
- [x] Added code has been documented
- [x] Added this change to [CHANGELOG.md](../../CHANGELOG.md) 
