### PR TITLE
Fix/onboarding screen small screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Visual hint of GPS accuracy while recording (#278)
 - Measurement GeoJson export (#279, #290)
-- Onboarding flow (#282)
+- Onboarding flow (#282, #293)
 
 ### Fixed
 

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/onboarding/OnboardingAcousticsKnowledgeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/onboarding/OnboardingAcousticsKnowledgeScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -86,11 +87,16 @@ fun OnboardingAcousticsKnowledgeScreen(
         primaryButtonAction = { router.goToNextStep() },
         modifier = modifier,
     ) {
-        Image(
-            painter = painterResource(Res.drawable.onboarding_illustration_knowledge),
-            contentScale = ContentScale.Inside,
-            contentDescription = null,
-        )
+        Box(
+            contentAlignment = Alignment.BottomCenter,
+            modifier = Modifier.weight(1f),
+        ) {
+            Image(
+                painter = painterResource(Res.drawable.onboarding_illustration_knowledge),
+                contentScale = ContentScale.Inside,
+                contentDescription = null,
+            )
+        }
 
         Spacer(modifier = Modifier.height(32.dp))
 

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/onboarding/OnboardingHowItWorksScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/onboarding/OnboardingHowItWorksScreen.kt
@@ -1,12 +1,14 @@
 package org.noiseplanet.noisecapture.ui.features.onboarding
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
@@ -36,11 +38,16 @@ fun OnboardingHowItWorksScreen(
         primaryButtonAction = { router.goToNextStep() },
         modifier = modifier,
     ) {
-        Image(
-            painter = painterResource(Res.drawable.onboarding_illustration_listening),
-            contentScale = ContentScale.Inside,
-            contentDescription = null,
-        )
+        Box(
+            contentAlignment = Alignment.BottomCenter,
+            modifier = Modifier.weight(1f),
+        ) {
+            Image(
+                painter = painterResource(Res.drawable.onboarding_illustration_listening),
+                contentScale = ContentScale.Inside,
+                contentDescription = null,
+            )
+        }
 
         Spacer(modifier = Modifier.height(32.dp))
 

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/onboarding/OnboardingLocationPermissionScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/onboarding/OnboardingLocationPermissionScreen.kt
@@ -1,6 +1,7 @@
 package org.noiseplanet.noisecapture.ui.features.onboarding
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -9,6 +10,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
@@ -71,11 +73,16 @@ fun OnboardingLocationPermissionScreen(
         secondaryButtonAction = { router.goToNextStep() },
         modifier = modifier,
     ) {
-        Image(
-            painter = painterResource(Res.drawable.permission_location_illustration),
-            contentScale = ContentScale.Inside,
-            contentDescription = null,
-        )
+        Box(
+            contentAlignment = Alignment.BottomCenter,
+            modifier = Modifier.weight(1f),
+        ) {
+            Image(
+                painter = painterResource(Res.drawable.permission_location_illustration),
+                contentScale = ContentScale.Inside,
+                contentDescription = null,
+            )
+        }
 
         Spacer(modifier = Modifier.height(64.dp))
 

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/onboarding/OnboardingMicPermissionScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/onboarding/OnboardingMicPermissionScreen.kt
@@ -1,6 +1,7 @@
 package org.noiseplanet.noisecapture.ui.features.onboarding
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -9,6 +10,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
@@ -70,11 +72,16 @@ fun OnboardingMicPermissionScreen(
         secondaryButtonAction = { router.goToNextStep() },
         modifier = modifier,
     ) {
-        Image(
-            painter = painterResource(Res.drawable.permission_microphone_illustration),
-            contentScale = ContentScale.Inside,
-            contentDescription = null,
-        )
+        Box(
+            contentAlignment = Alignment.BottomCenter,
+            modifier = Modifier.weight(1f),
+        ) {
+            Image(
+                painter = painterResource(Res.drawable.permission_microphone_illustration),
+                contentScale = ContentScale.Inside,
+                contentDescription = null,
+            )
+        }
 
         Spacer(modifier = Modifier.height(64.dp))
 

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/onboarding/OnboardingScreenContainer.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/onboarding/OnboardingScreenContainer.kt
@@ -38,11 +38,11 @@ fun OnboardingScreenContainer(
             modifier = modifier.widthIn(max = AdaptiveUtil.MAX_FULL_SCREEN_WIDTH)
                 .padding(horizontal = 24.dp)
                 .padding(top = 16.dp)
-                .paddingBottomWithInsets(16.dp, withoutNavBar = 48.dp),
+                .paddingBottomWithInsets(16.dp, withoutNavBar = 32.dp),
         ) {
             content()
 
-            Spacer(modifier = Modifier.height(64.dp))
+            Spacer(modifier = Modifier.height(32.dp))
 
             NCButton(
                 viewModel = NCButtonViewModel(title = primaryButtonTitle, hasDropShadow = true),

--- a/composeApp/src/iosMain/kotlin/org/noiseplanet/noisecapture/IOSPlatformModule.kt
+++ b/composeApp/src/iosMain/kotlin/org/noiseplanet/noisecapture/IOSPlatformModule.kt
@@ -3,7 +3,7 @@ package org.noiseplanet.noisecapture
 import IOSPlatform
 import Platform
 import com.russhwolf.settings.ExperimentalSettingsImplementation
-import com.russhwolf.settings.KeychainSettings
+import com.russhwolf.settings.NSUserDefaultsSettings
 import com.russhwolf.settings.Settings
 import org.koin.core.module.Module
 import org.koin.dsl.module
@@ -21,7 +21,7 @@ import org.noiseplanet.noisecapture.services.location.UserLocationProvider
 import org.noiseplanet.noisecapture.services.storage.FileSystemService
 import org.noiseplanet.noisecapture.services.storage.IOSFileSystemService
 import org.noiseplanet.noisecapture.util.IOSFilePickerEventBus
-import platform.Foundation.NSBundle
+import platform.Foundation.NSUserDefaults
 
 /**
  * Registers koin components specific to this platform
@@ -47,9 +47,7 @@ val platformModule: Module = module {
     }
 
     single<Settings> {
-        NSBundle.mainBundle.bundleIdentifier
-            ?.let { KeychainSettings(it) }
-            ?: KeychainSettings()
+        NSUserDefaultsSettings(NSUserDefaults.standardUserDefaults)
     }
 
     single<AudioRecordingService> {


### PR DESCRIPTION
# Description

On smaller devices, onboarding layout would shrink the continue button.

## Changes

- Reduce spacing around continue button a little bit
- If necessary, shrink the image at the top instead of the actual page content.

## Linked issues

- #292 

## Remaining TODOs

N/A

## Checklist

- [x] Code compiles correctly on all platforms
- [x] All pre-existing tests are passing
- [x] If needed, new tests have been added
- [ ] Extended the README / documentation if necessary
- [ ] Added code has been documented
- [x] Added this change to [CHANGELOG.md](../../CHANGELOG.md) 
