### PR TITLE
Feature/persistent tiles cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Caching of map tiles for faster loading (#298)
+
 ## [0.9.0] - 2026-05-13
 
 ### Added

--- a/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/AndroidPlatformModule.kt
+++ b/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/AndroidPlatformModule.kt
@@ -21,7 +21,9 @@ import org.noiseplanet.noisecapture.services.location.AndroidUserLocationProvide
 import org.noiseplanet.noisecapture.services.location.UserLocationProvider
 import org.noiseplanet.noisecapture.services.measurement.AndroidRecordingService
 import org.noiseplanet.noisecapture.services.measurement.RecordingService
+import org.noiseplanet.noisecapture.services.storage.AndroidCacheFileSystemService
 import org.noiseplanet.noisecapture.services.storage.AndroidFileSystemService
+import org.noiseplanet.noisecapture.services.storage.CacheFileSystemService
 import org.noiseplanet.noisecapture.services.storage.FileSystemService
 
 /**
@@ -65,6 +67,10 @@ val platformModule: Module = module {
 
     single<FileSystemService> {
         AndroidFileSystemService()
+    }
+
+    single<CacheFileSystemService> {
+        AndroidCacheFileSystemService()
     }
 
     single {

--- a/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/services/storage/AndroidCacheFileSystemService.kt
+++ b/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/services/storage/AndroidCacheFileSystemService.kt
@@ -1,0 +1,9 @@
+package org.noiseplanet.noisecapture.services.storage
+
+
+class AndroidCacheFileSystemService : AndroidFileSystemService(), CacheFileSystemService {
+
+    override fun getRootDirectory(): String {
+        return context.cacheDir.absolutePath
+    }
+}

--- a/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/services/storage/AndroidFileSystemService.kt
+++ b/composeApp/src/androidMain/kotlin/org/noiseplanet/noisecapture/services/storage/AndroidFileSystemService.kt
@@ -14,14 +14,14 @@ import java.io.FileOutputStream
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 
-class AndroidFileSystemService : FileSystemService, KoinComponent {
+open class AndroidFileSystemService : FileSystemService, KoinComponent {
 
     // - Properties
 
     override val dispatcher: CoroutineDispatcher
         get() = Dispatchers.IO
 
-    private val context: Context by inject()
+    protected val context: Context by inject()
     private val filePickerEventBus: AndroidFilePickerEventBus by inject()
 
 

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/Koin.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/Koin.kt
@@ -4,6 +4,7 @@ import org.koin.core.context.startKoin
 import org.koin.core.module.Module
 import org.koin.dsl.module
 import org.koin.mp.KoinPlatform
+import org.noiseplanet.noisecapture.http.httpModule
 import org.noiseplanet.noisecapture.permission.defaultPermissionModule
 import org.noiseplanet.noisecapture.permission.platformPermissionModule
 import org.noiseplanet.noisecapture.services.servicesModule
@@ -27,6 +28,7 @@ fun initKoin(
 
         modules(
             storageModule,
+            httpModule,
             servicesModule,
             coordinatorModule,
 

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/http/FilesystemHttpCacheStorage.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/http/FilesystemHttpCacheStorage.kt
@@ -4,7 +4,12 @@ import io.ktor.client.plugins.cache.storage.CacheStorage
 import io.ktor.client.plugins.cache.storage.CachedResponseData
 import io.ktor.http.Url
 import io.ktor.util.date.GMTDate
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
+import nl.jacobras.humanreadable.HumanReadable
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import org.noiseplanet.noisecapture.log.Logger
@@ -12,14 +17,31 @@ import org.noiseplanet.noisecapture.services.storage.CacheFileSystemService
 import org.noiseplanet.noisecapture.util.injectLogger
 
 
-class FilesystemHttpCacheStorage(
+class FilesystemHttpCacheStorage : CacheStorage, KoinComponent {
 
-) : CacheStorage, KoinComponent {
+    // - Constants
+
+    companion object {
+
+        const val MAX_CACHE_SIZE_BYTES: Long = 25 * 1024 * 1024 // 25MB
+    }
+
 
     // - Properties
 
     private val logger: Logger by injectLogger()
     private val cacheSystemService: CacheFileSystemService by inject()
+
+    private var entries: MutableMap<String, CachedResponseMetadata>? = null
+
+    private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+
+
+    // - Lifecycle
+
+    init {
+        scope.launch { controlCacheSize() }
+    }
 
 
     // - Public functions
@@ -28,9 +50,9 @@ class FilesystemHttpCacheStorage(
         url: Url,
         data: CachedResponseData,
     ) {
-        logger.info("CACHE STORE 🦫")
         val cacheKey = cacheKeyFromUrl(url)
         val metadataKey = "$cacheKey.meta"
+        val metadata = data.metadata()
 
         // Write response to cache storage
         cacheSystemService.write(fileUri = cacheKey, bytes = data.body)
@@ -38,18 +60,20 @@ class FilesystemHttpCacheStorage(
         // Write metadata
         cacheSystemService.writeString(
             fileUri = metadataKey,
-            text = Json.encodeToString(data.metadata())
+            text = Json.encodeToString(metadata)
         )
 
-        // TODO: Check cache size and remove entries if needed
-//        enforceCacheSize()
+        // Store metadata in in-memory index
+        entries?.set(cacheKey, metadata)
+
+        // Check cache size and remove oldest entries if needed
+        controlCacheSize()
     }
 
     override suspend fun find(
         url: Url,
         varyKeys: Map<String, String>,
     ): CachedResponseData? {
-//        logger.info("CACHE FIND")
         val cacheKey = cacheKeyFromUrl(url)
         val metadataKey = "$cacheKey.meta"
 
@@ -73,7 +97,6 @@ class FilesystemHttpCacheStorage(
     }
 
     override suspend fun findAll(url: Url): Set<CachedResponseData> {
-//        logger.info("CACHE FIND ALL")
         return find(url, emptyMap())
             ?.let { setOf(it) }
             ?: emptySet()
@@ -88,6 +111,7 @@ class FilesystemHttpCacheStorage(
         val metadataKey = "$cacheKey.meta"
         cacheSystemService.delete(cacheKey)
         cacheSystemService.delete(metadataKey)
+        entries?.remove(cacheKey)
     }
 
     override suspend fun removeAll(url: Url) {
@@ -100,5 +124,39 @@ class FilesystemHttpCacheStorage(
 
     private fun cacheKeyFromUrl(url: Url): String {
         return url.encodedPath.replace("/", "_")
+    }
+
+    private suspend fun controlCacheSize() {
+        // The first time we control cache size, read all current metadata files
+        if (entries == null) {
+            val metaDataPaths = cacheSystemService.list().filter { it.endsWith(".meta") }
+            entries = mutableMapOf()
+
+            for (path in metaDataPaths) {
+                val metadata: CachedResponseMetadata = cacheSystemService.readString(path)
+                    ?.let { Json.decodeFromString(it) }
+                    ?: continue
+                entries?.set(cacheKeyFromUrl(metadata.url), metadata)
+            }
+        }
+
+        // Calculate cache size from entries
+        var totalCacheSize = 0L
+        entries?.values?.sortedByDescending { it.expires }?.forEach { metadata ->
+            totalCacheSize += metadata.bodySize
+
+            // If cache size is over limit, delete entries that will expire first
+            if (totalCacheSize > MAX_CACHE_SIZE_BYTES) {
+                removeAll(metadata.url)
+            }
+        }
+
+        logger.debug(
+            "CACHE SIZE: ${HumanReadable.fileSize(totalCacheSize)} / ${
+                HumanReadable.fileSize(
+                    MAX_CACHE_SIZE_BYTES
+                )
+            }"
+        )
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/http/FilesystemHttpCacheStorage.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/http/FilesystemHttpCacheStorage.kt
@@ -1,0 +1,104 @@
+package org.noiseplanet.noisecapture.http
+
+import io.ktor.client.plugins.cache.storage.CacheStorage
+import io.ktor.client.plugins.cache.storage.CachedResponseData
+import io.ktor.http.Url
+import io.ktor.util.date.GMTDate
+import kotlinx.serialization.json.Json
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import org.noiseplanet.noisecapture.log.Logger
+import org.noiseplanet.noisecapture.services.storage.CacheFileSystemService
+import org.noiseplanet.noisecapture.util.injectLogger
+
+
+class FilesystemHttpCacheStorage(
+
+) : CacheStorage, KoinComponent {
+
+    // - Properties
+
+    private val logger: Logger by injectLogger()
+    private val cacheSystemService: CacheFileSystemService by inject()
+
+
+    // - Public functions
+
+    override suspend fun store(
+        url: Url,
+        data: CachedResponseData,
+    ) {
+        logger.info("CACHE STORE 🦫")
+        val cacheKey = cacheKeyFromUrl(url)
+        val metadataKey = "$cacheKey.meta"
+
+        // Write response to cache storage
+        cacheSystemService.write(fileUri = cacheKey, bytes = data.body)
+
+        // Write metadata
+        cacheSystemService.writeString(
+            fileUri = metadataKey,
+            text = Json.encodeToString(data.metadata())
+        )
+
+        // TODO: Check cache size and remove entries if needed
+//        enforceCacheSize()
+    }
+
+    override suspend fun find(
+        url: Url,
+        varyKeys: Map<String, String>,
+    ): CachedResponseData? {
+//        logger.info("CACHE FIND")
+        val cacheKey = cacheKeyFromUrl(url)
+        val metadataKey = "$cacheKey.meta"
+
+        // If entry (or associated metadata) not found, return null
+        if (!cacheSystemService.exists(cacheKey) || !cacheSystemService.exists(metadataKey)) {
+            return null
+        }
+        // Try to read cached value's expiration time
+        val metadata: CachedResponseMetadata = cacheSystemService.readString(metadataKey)
+            ?.let { Json.decodeFromString(it) }
+            ?: return null
+        // If cached data has expired, delete it
+        if (GMTDate() > metadata.expires) {
+            remove(url, varyKeys)
+            return null
+        }
+
+        // Return cached response
+        val body = cacheSystemService.read(cacheKey) ?: return null
+        return metadata.withBody(body)
+    }
+
+    override suspend fun findAll(url: Url): Set<CachedResponseData> {
+//        logger.info("CACHE FIND ALL")
+        return find(url, emptyMap())
+            ?.let { setOf(it) }
+            ?: emptySet()
+    }
+
+    override suspend fun remove(
+        url: Url,
+        varyKeys: Map<String, String>,
+    ) {
+        logger.info("CACHE REMOVE")
+        val cacheKey = cacheKeyFromUrl(url)
+        val metadataKey = "$cacheKey.meta"
+        cacheSystemService.delete(cacheKey)
+        cacheSystemService.delete(metadataKey)
+    }
+
+    override suspend fun removeAll(url: Url) {
+        logger.info("CACHE REMOVE ALL")
+        remove(url, emptyMap())
+    }
+
+
+    // - Private functions
+
+    private fun cacheKeyFromUrl(url: Url): String {
+        return url.encodedPath.replace("/", "_")
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/http/HttpModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/http/HttpModule.kt
@@ -1,0 +1,25 @@
+package org.noiseplanet.noisecapture.http
+
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.HttpRequestRetry
+import io.ktor.client.plugins.cache.HttpCache
+import org.koin.dsl.module
+
+
+val httpModule = module {
+
+    single<HttpClient> {
+        HttpClient {
+            install(HttpCache) {
+                val cacheStorage = FilesystemHttpCacheStorage()
+                this.privateStorage(cacheStorage)
+                this.publicStorage(cacheStorage)
+            }
+
+            install(HttpRequestRetry) {
+                retryOnServerErrors(maxRetries = 5)
+                exponentialDelay()
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/http/KtorExtensions.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/http/KtorExtensions.kt
@@ -33,6 +33,7 @@ internal data class CachedResponseMetadata(
     val expires: GMTDate,
     val headers: Map<String, List<String>>,
     val varyKeys: Map<String, String>,
+    val bodySize: Long,
 ) {
 
     override fun equals(other: Any?): Boolean {
@@ -89,7 +90,8 @@ internal fun CachedResponseData.metadata(): CachedResponseMetadata {
         headers = headers.entries().associate { it.key to it.value },
         varyKeys = varyKeys,
         version = httpProtocolVersionCopy,
-        expires = expires
+        expires = expires,
+        bodySize = body.size.toLong()
     )
 }
 

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/http/KtorExtensions.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/http/KtorExtensions.kt
@@ -1,0 +1,117 @@
+package org.noiseplanet.noisecapture.http
+
+import io.ktor.client.plugins.cache.storage.CachedResponseData
+import io.ktor.http.HttpProtocolVersion
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.Url
+import io.ktor.http.headersOf
+import io.ktor.util.date.GMTDate
+import kotlinx.serialization.Serializable
+
+/**
+ * Serializable copy of [CachedResponseData] (except for the [ByteArray] body) for persistence.
+ *
+ * Uses serializable types (e.g. [HttpStatusCodeCopy], [HttpProtocolVersionCopy]) so the response
+ * can be encoded/decoded across platforms.
+ *
+ * @property url The request URL.
+ * @property statusCode HTTP status code copy.
+ * @property requestTime Time of the original request.
+ * @property responseTime Time of the cached response.
+ * @property version HTTP protocol version copy.
+ * @property expires Expiration time of the cached entry.
+ * @property headers Response headers.
+ * @property varyKeys Vary keys for content negotiation.
+ */
+@Serializable
+internal data class CachedResponseMetadata(
+    val url: Url,
+    val statusCode: HttpStatusCodeCopy,
+    val requestTime: GMTDate,
+    val responseTime: GMTDate,
+    val version: HttpProtocolVersionCopy,
+    val expires: GMTDate,
+    val headers: Map<String, List<String>>,
+    val varyKeys: Map<String, String>,
+) {
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is CachedResponseMetadata) return false
+
+        if (url != other.url) return false
+        if (varyKeys != other.varyKeys) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = url.hashCode()
+        result = 31 * result + varyKeys.hashCode()
+        return result
+    }
+}
+
+/**
+ * Serializable copy of [io.ktor.http.HttpStatusCode] for persistence.
+ *
+ * @property value HTTP status code value (e.g. 200, 404).
+ * @property description Status description (e.g. "OK", "Not Found").
+ */
+@Serializable
+internal data class HttpStatusCodeCopy(val value: Int, val description: String)
+
+/**
+ * Serializable copy of [io.ktor.http.HttpProtocolVersion] for persistence.
+ *
+ * @property name Protocol name (e.g. "HTTP").
+ * @property major Major version number.
+ * @property minor Minor version number.
+ */
+@Serializable
+internal data class HttpProtocolVersionCopy(val name: String, val major: Int, val minor: Int)
+
+internal fun CachedResponseData.metadata(): CachedResponseMetadata {
+    val httpStatusCodeCopy = HttpStatusCodeCopy(
+        value = statusCode.value,
+        description = statusCode.description
+    )
+    val httpProtocolVersionCopy = HttpProtocolVersionCopy(
+        name = version.name,
+        major = version.major,
+        minor = version.minor
+    )
+    return CachedResponseMetadata(
+        url = url,
+        statusCode = httpStatusCodeCopy,
+        requestTime = requestTime,
+        responseTime = responseTime,
+        headers = headers.entries().associate { it.key to it.value },
+        varyKeys = varyKeys,
+        version = httpProtocolVersionCopy,
+        expires = expires
+    )
+}
+
+internal fun CachedResponseMetadata.withBody(body: ByteArray): CachedResponseData {
+    val httpStatusCode = HttpStatusCode(
+        value = statusCode.value,
+        description = statusCode.description
+    )
+    val httpProtocolVersion = HttpProtocolVersion(
+        name = version.name,
+        major = version.major,
+        minor = version.minor
+    )
+    return CachedResponseData(
+        url = url,
+        statusCode = httpStatusCode,
+        requestTime = requestTime,
+        responseTime = responseTime,
+        headers = headersOf(*headers.map { it.key to it.value }.toTypedArray()),
+        varyKeys = varyKeys,
+        body = body,
+        version = httpProtocolVersion,
+        expires = expires
+    )
+}

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/storage/CacheFileSystemService.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/storage/CacheFileSystemService.kt
@@ -1,0 +1,42 @@
+package org.noiseplanet.noisecapture.services.storage
+
+import kotlinx.io.files.SystemFileSystem
+
+
+/**
+ * Child interface of [FileSystemService] to be used to interact with files in cache storage
+ * instead of application storage.
+ */
+interface CacheFileSystemService : FileSystemService {
+
+    /**
+     * Gets the current size of all currently cached files in bytes.
+     *
+     * @return Current cache size in bytes.
+     */
+    suspend fun getTotalCacheSize(): Long? = with(dispatcher) {
+        getDirSize("")
+    }
+
+    /**
+     * Gets the size of a directory in bytes.
+     *
+     * @param directoryUri Path to the directory.
+     * @return Size in bytes or null if not found.
+     */
+    suspend fun getDirSize(directoryUri: String): Long? = with(dispatcher) {
+        val path = getAbsolutePath(directoryUri) ?: return@with null
+        val rootDir = getRootDirectory() ?: return@with null
+
+        SystemFileSystem.list(path)
+            .fold(0L) { acc, path ->
+                val metadata = SystemFileSystem.metadataOrNull(path) ?: return@fold acc
+
+                if (metadata.isRegularFile) {
+                    acc + metadata.size
+                } else {
+                    acc + (getDirSize(path.toString().replaceFirst(rootDir, "")) ?: 0)
+                }
+            }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/storage/CacheFileSystemService.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/storage/CacheFileSystemService.kt
@@ -1,42 +1,8 @@
 package org.noiseplanet.noisecapture.services.storage
 
-import kotlinx.io.files.SystemFileSystem
-
 
 /**
  * Child interface of [FileSystemService] to be used to interact with files in cache storage
  * instead of application storage.
  */
-interface CacheFileSystemService : FileSystemService {
-
-    /**
-     * Gets the current size of all currently cached files in bytes.
-     *
-     * @return Current cache size in bytes.
-     */
-    suspend fun getTotalCacheSize(): Long? = with(dispatcher) {
-        getDirSize("")
-    }
-
-    /**
-     * Gets the size of a directory in bytes.
-     *
-     * @param directoryUri Path to the directory.
-     * @return Size in bytes or null if not found.
-     */
-    suspend fun getDirSize(directoryUri: String): Long? = with(dispatcher) {
-        val path = getAbsolutePath(directoryUri) ?: return@with null
-        val rootDir = getRootDirectory() ?: return@with null
-
-        SystemFileSystem.list(path)
-            .fold(0L) { acc, path ->
-                val metadata = SystemFileSystem.metadataOrNull(path) ?: return@fold acc
-
-                if (metadata.isRegularFile) {
-                    acc + metadata.size
-                } else {
-                    acc + (getDirSize(path.toString().replaceFirst(rootDir, "")) ?: 0)
-                }
-            }
-    }
-}
+interface CacheFileSystemService : FileSystemService

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/storage/FileSystemService.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/storage/FileSystemService.kt
@@ -3,6 +3,7 @@ package org.noiseplanet.noisecapture.services.storage
 import io.ktor.utils.io.core.toByteArray
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import kotlinx.io.buffered
 import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
@@ -26,12 +27,12 @@ interface FileSystemService {
      * @param fileUri File URI.
      * @return File contents as [ByteArray], null if file doesn't exist.
      */
-    suspend fun read(fileUri: String): ByteArray? = with(dispatcher) {
-        val path = getAbsolutePath(fileUri) ?: return@with null
-        if (!SystemFileSystem.exists(path)) return@with null
+    suspend fun read(fileUri: String): ByteArray? = withContext(dispatcher) {
+        val path = getAbsolutePath(fileUri) ?: return@withContext null
+        if (!SystemFileSystem.exists(path)) return@withContext null
 
         runCatching {
-            SystemFileSystem.source(path).buffered().readByteArray()
+            SystemFileSystem.source(path).buffered().use { it.readByteArray() }
         }.getOrNull()
     }
 
@@ -53,8 +54,8 @@ interface FileSystemService {
      * @param append If true, appends bytes to previously existing file contents. Defaults to false.
      */
     suspend fun write(fileUri: String, bytes: ByteArray, append: Boolean = false) =
-        with(dispatcher) {
-            val path = getAbsolutePath(fileUri) ?: return@with
+        withContext(dispatcher) {
+            val path = getAbsolutePath(fileUri) ?: return@withContext
             path.parent?.let { SystemFileSystem.createDirectories(it) }
 
             SystemFileSystem.sink(path, append)
@@ -79,8 +80,8 @@ interface FileSystemService {
      * @param fileUri File URI.
      * @return File size in bytes, null if not found.
      */
-    suspend fun size(fileUri: String): Long? = with(dispatcher) {
-        val path = getAbsolutePath(fileUri) ?: return@with null
+    suspend fun size(fileUri: String): Long? = withContext(dispatcher) {
+        val path = getAbsolutePath(fileUri) ?: return@withContext null
 
         SystemFileSystem.metadataOrNull(path)?.size
     }
@@ -90,8 +91,8 @@ interface FileSystemService {
      *
      * @param fileUri File URI.
      */
-    suspend fun delete(fileUri: String) = with(dispatcher) {
-        val path = getAbsolutePath(fileUri) ?: return@with
+    suspend fun delete(fileUri: String) = withContext(dispatcher) {
+        val path = getAbsolutePath(fileUri) ?: return@withContext
 
         SystemFileSystem.delete(path, mustExist = false)
     }
@@ -102,10 +103,25 @@ interface FileSystemService {
      * @param fileUri File URI.
      * @return True if the file at the given URI exists, false otherwise.
      */
-    suspend fun exists(fileUri: String): Boolean = with(dispatcher) {
-        val path = getAbsolutePath(fileUri) ?: return@with false
+    suspend fun exists(fileUri: String): Boolean = withContext(dispatcher) {
+        val path = getAbsolutePath(fileUri) ?: return@withContext false
 
         SystemFileSystem.exists(path)
+    }
+
+    /**
+     * Lists contents found at given URI.
+     *
+     * @param uri Directory URI
+     * @return URIs of directory children
+     */
+    suspend fun list(uri: String = ""): List<String> = withContext(dispatcher) {
+        val path = getAbsolutePath(uri) ?: return@withContext emptyList()
+        val root = getRootDirectory().toString()
+
+        SystemFileSystem.list(path).map { path ->
+            path.toString().replaceFirst(root, "")
+        }
     }
 
     /**

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/storage/FileSystemService.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/storage/FileSystemService.kt
@@ -41,8 +41,8 @@ interface FileSystemService {
      * @param fileUri File URI.
      * @return File contents as [String], null if file doesn't exist.
      */
-    suspend fun readString(fileUri: String): String? = with(dispatcher) {
-        read(fileUri)?.decodeToString()
+    suspend fun readString(fileUri: String): String? {
+        return read(fileUri)?.decodeToString()
     }
 
     /**
@@ -69,10 +69,9 @@ interface FileSystemService {
      * @param text String to write.
      * @param append If true, appends bytes to previously existing file contents. Defaults to false.
      */
-    suspend fun writeString(fileUri: String, text: String, append: Boolean = false) =
-        with(dispatcher) {
-            write(fileUri, text.toByteArray(), append)
-        }
+    suspend fun writeString(fileUri: String, text: String, append: Boolean = false) {
+        write(fileUri, text.toByteArray(), append)
+    }
 
     /**
      * Gets the size of the file at the given URI, in bytes.
@@ -95,6 +94,18 @@ interface FileSystemService {
         val path = getAbsolutePath(fileUri) ?: return@with
 
         SystemFileSystem.delete(path, mustExist = false)
+    }
+
+    /**
+     * True if the file at the given URI exists, false otherwise.
+     *
+     * @param fileUri File URI.
+     * @return True if the file at the given URI exists, false otherwise.
+     */
+    suspend fun exists(fileUri: String): Boolean = with(dispatcher) {
+        val path = getAbsolutePath(fileUri) ?: return@with false
+
+        SystemFileSystem.exists(path)
     }
 
     /**

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/map/MapViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/map/MapViewModel.kt
@@ -376,7 +376,7 @@ class MapViewModel(
                 id = USER_LOCATION_MARKER_ID,
                 x = x,
                 y = y,
-                relativeOffset = Offset(x = 0.5f, y = 0.5f),
+                relativeOffset = Offset(x = -0.5f, y = -0.5f),
             ) {
                 UserLocationMarker(mapRotationDegrees = mapState.rotation)
             }

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/map/RemoteTileStreamProvider.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/map/RemoteTileStreamProvider.kt
@@ -9,6 +9,7 @@ import io.ktor.http.isSuccess
 import kotlinx.io.Buffer
 import kotlinx.io.RawSource
 import org.koin.core.component.KoinComponent
+import org.noiseplanet.noisecapture.http.FilesystemHttpCacheStorage
 import org.noiseplanet.noisecapture.log.Logger
 import org.noiseplanet.noisecapture.util.injectLogger
 import ovh.plrapps.mapcompose.core.TileStreamProvider
@@ -29,19 +30,15 @@ class RemoteTileStreamProvider(
     // - Properties
 
     private val httpClient = HttpClient {
-        // TODO: Enable persistent storage caching for tiles up to a few megabytes
-        //       to avoid reloading the same map area everytime a user opens the app.
-        //       This would require to provide a multiplatform file storage API that is not
-        //       currently provided by Ktor, but a few tweaks to our KStore implementation should
-        //       probably do the job.
-        install(HttpCache)
+        install(HttpCache) {
+            this.privateStorage(FilesystemHttpCacheStorage())
+            this.publicStorage(FilesystemHttpCacheStorage())
+        }
 
         install(HttpRequestRetry) {
             retryOnServerErrors(maxRetries = 5)
             exponentialDelay()
         }
-
-        // TODO: Configure logging with ability to enable/disable
     }
 
     private val logger: Logger by injectLogger()

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/map/RemoteTileStreamProvider.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/map/RemoteTileStreamProvider.kt
@@ -1,15 +1,13 @@
 package org.noiseplanet.noisecapture.ui.components.map
 
 import io.ktor.client.HttpClient
-import io.ktor.client.plugins.HttpRequestRetry
-import io.ktor.client.plugins.cache.HttpCache
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsBytes
 import io.ktor.http.isSuccess
 import kotlinx.io.Buffer
 import kotlinx.io.RawSource
 import org.koin.core.component.KoinComponent
-import org.noiseplanet.noisecapture.http.FilesystemHttpCacheStorage
+import org.koin.core.component.inject
 import org.noiseplanet.noisecapture.log.Logger
 import org.noiseplanet.noisecapture.util.injectLogger
 import ovh.plrapps.mapcompose.core.TileStreamProvider
@@ -29,18 +27,7 @@ class RemoteTileStreamProvider(
 
     // - Properties
 
-    private val httpClient = HttpClient {
-        install(HttpCache) {
-            this.privateStorage(FilesystemHttpCacheStorage())
-            this.publicStorage(FilesystemHttpCacheStorage())
-        }
-
-        install(HttpRequestRetry) {
-            retryOnServerErrors(maxRetries = 5)
-            exponentialDelay()
-        }
-    }
-
+    private val httpClient: HttpClient by inject()
     private val logger: Logger by injectLogger()
 
 

--- a/composeApp/src/iosMain/kotlin/org/noiseplanet/noisecapture/IOSPlatformModule.kt
+++ b/composeApp/src/iosMain/kotlin/org/noiseplanet/noisecapture/IOSPlatformModule.kt
@@ -18,7 +18,9 @@ import org.noiseplanet.noisecapture.services.audio.IOSMicrophoneProviderService
 import org.noiseplanet.noisecapture.services.audio.MicrophoneProviderService
 import org.noiseplanet.noisecapture.services.location.IOSUserLocationProvider
 import org.noiseplanet.noisecapture.services.location.UserLocationProvider
+import org.noiseplanet.noisecapture.services.storage.CacheFileSystemService
 import org.noiseplanet.noisecapture.services.storage.FileSystemService
+import org.noiseplanet.noisecapture.services.storage.IOSCacheFileSystemService
 import org.noiseplanet.noisecapture.services.storage.IOSFileSystemService
 import org.noiseplanet.noisecapture.util.IOSFilePickerEventBus
 import platform.Foundation.NSUserDefaults
@@ -56,6 +58,10 @@ val platformModule: Module = module {
 
     single<FileSystemService> {
         IOSFileSystemService()
+    }
+
+    single<CacheFileSystemService> {
+        IOSCacheFileSystemService()
     }
 
     single<IOSFilePickerEventBus> {

--- a/composeApp/src/iosMain/kotlin/org/noiseplanet/noisecapture/services/storage/IOSCacheFileSystemService.kt
+++ b/composeApp/src/iosMain/kotlin/org/noiseplanet/noisecapture/services/storage/IOSCacheFileSystemService.kt
@@ -1,0 +1,18 @@
+package org.noiseplanet.noisecapture.services.storage
+
+import platform.Foundation.NSCachesDirectory
+import platform.Foundation.NSURL
+import platform.Foundation.NSUserDomainMask
+
+
+open class IOSCacheFileSystemService : IOSFileSystemService(), CacheFileSystemService {
+
+    override fun getRootDirectory(): String? {
+        val urls = fileManager.URLsForDirectory(
+            directory = NSCachesDirectory,
+            inDomains = NSUserDomainMask
+        )
+        val url = urls.firstOrNull() as? NSURL? ?: return null
+        return url.path
+    }
+}

--- a/composeApp/src/iosMain/kotlin/org/noiseplanet/noisecapture/services/storage/IOSFileSystemService.kt
+++ b/composeApp/src/iosMain/kotlin/org/noiseplanet/noisecapture/services/storage/IOSFileSystemService.kt
@@ -24,14 +24,14 @@ import kotlin.time.ExperimentalTime
 
 
 @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class, ExperimentalTime::class)
-class IOSFileSystemService : FileSystemService, KoinComponent {
+open class IOSFileSystemService : FileSystemService, KoinComponent {
 
     // - Properties
 
     private val logger: Logger by injectLogger()
     private val filePickerEventBus: IOSFilePickerEventBus by inject()
 
-    private val fileManager: NSFileManager = NSFileManager.defaultManager
+    protected val fileManager: NSFileManager = NSFileManager.defaultManager
 
 
     // - FileSystemService

--- a/composeApp/src/wasmJsMain/kotlin/org/noiseplanet/noisecapture/JSPlatformModule.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/noiseplanet/noisecapture/JSPlatformModule.kt
@@ -4,6 +4,8 @@ import Platform
 import WasmJSPlatform
 import com.russhwolf.settings.Settings
 import com.russhwolf.settings.StorageSettings
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.HttpRequestRetry
 import org.koin.core.module.Module
 import org.koin.dsl.module
 import org.noiseplanet.noisecapture.audio.AudioSource
@@ -57,5 +59,17 @@ val platformModule: Module = module {
 
     single<MicrophoneProviderService> {
         JSMicrophoneProviderService()
+    }
+
+    single<HttpClient> {
+        HttpClient {
+
+            // Override HttpClient configuration and let browser handle caching for WasmJS target
+
+            install(HttpRequestRetry) {
+                retryOnServerErrors(maxRetries = 5)
+                exponentialDelay()
+            }
+        }
     }
 }


### PR DESCRIPTION
# Description

Adds persistent cache storage using Ktor and `FileSystemService`. This makes the loading of tiles around the user (frequently accessed in theory) faster, and reduces the network consumption and battery usage of the app.

## Changes

- Adds a `CacheFileSystemService` with the same methods as `FileSystemService`, except it should use the device's cache directory as root instead of documents.
- Adds a Ktor `CacheStorage` implementation that stores results of requests in persistent storage, along with corresponding metadata (expiration time, URL, size, etc...)
  - This class controls that the cache storage doesn't exceed a certain limit, if that's the case, elements that expire sooner will be removed first to make room for new items.
  - On browser, this cache mechanism is disabled as it is already handled on the browser side.
  - Since the cache behaviour (caching/not caching, expiration, etc) is determined by response headers, it is the server's responsibility to determine what should be cached or not. Currently, only background tiles are cached and foreground tiles are fetched everytime (which is what we want in order to always get freshest data for sound level tiles)

## Linked issues

- #158 

## Remaining TODOs

- For now the implementation is quite basic (only store the raw request data as bytes). If needed it could be optimised by using compression/decompression of data before storing.

## Checklist

- [x] Code compiles correctly on all platforms
- [x] All pre-existing tests are passing
- [ ] If needed, new tests have been added
- [ ] Extended the README / documentation if necessary
- [x] Added code has been documented
- [x] Added this change to [CHANGELOG.md](../../CHANGELOG.md)