### PR TITLE
Remember last user location as default map centroid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Caching of map tiles for faster loading (#298)
 
+### Changed
+
+- Use last known user location as map default centroid (#300)
+
 ## [0.9.0] - 2026-05-13
 
 ### Added

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/model/dao/LocationRecord.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/model/dao/LocationRecord.kt
@@ -1,5 +1,7 @@
 package org.noiseplanet.noisecapture.model.dao
 
+import kotlinx.serialization.Serializable
+
 /**
  * Location data at a given time
  *
@@ -20,6 +22,7 @@ package org.noiseplanet.noisecapture.model.dao
  * @param directionAccuracy The accuracy of the direction value, measured in degrees.
  *                          On Android, only available since SDK 26 (Oreo), hence optional.
  */
+@Serializable
 data class LocationRecord(
     val timestamp: Long,
 

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/location/DefaultUserLocationService.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/location/DefaultUserLocationService.kt
@@ -8,12 +8,15 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import org.noiseplanet.noisecapture.model.dao.LocationRecord
 import org.noiseplanet.noisecapture.permission.Permission
 import org.noiseplanet.noisecapture.permission.PermissionState
 import org.noiseplanet.noisecapture.services.permission.PermissionService
+import org.noiseplanet.noisecapture.services.settings.SettingsKey
+import org.noiseplanet.noisecapture.services.settings.UserSettingsService
 import org.noiseplanet.noisecapture.util.stateInWhileSubscribed
 
 
@@ -26,6 +29,7 @@ open class DefaultUserLocationService : UserLocationService, KoinComponent {
     // - Properties
 
     private val locationProvider: UserLocationProvider by inject()
+    private val settingsService: UserSettingsService by inject()
 
     protected val permissionService: PermissionService by inject()
     protected val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
@@ -55,5 +59,18 @@ open class DefaultUserLocationService : UserLocationService, KoinComponent {
 
     override fun stopUpdatingLocation() {
         locationProvider.stopUpdatingLocation()
+    }
+
+
+    // - Lifecycle
+
+    init {
+        scope.launch {
+            liveLocation.collect {
+                // Listen to live location updates and store the last known user location
+                // to use as default map centroid
+                settingsService.set(SettingsKey.MapLastKnownLocation, it)
+            }
+        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/settings/SettingsKey.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/settings/SettingsKey.kt
@@ -1,7 +1,9 @@
 package org.noiseplanet.noisecapture.services.settings
 
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.builtins.nullable
 import kotlinx.serialization.builtins.serializer
+import org.noiseplanet.noisecapture.model.dao.LocationRecord
 import org.noiseplanet.noisecapture.model.enums.AcousticsKnowledgeLevel
 import org.noiseplanet.noisecapture.model.enums.CalibrationTestAudioOutput
 import org.noiseplanet.noisecapture.model.enums.SpectrogramScaleMode
@@ -114,6 +116,11 @@ sealed class SettingsKey<T>(
     data object SettingMapMaxMeasurementsCount : SettingsKey<UInt>(
         UInt.serializer(),
         defaultValue = 500u,
+    )
+
+    data object MapLastKnownLocation : SettingsKey<LocationRecord?>(
+        LocationRecord.serializer().nullable,
+        defaultValue = null,
     )
 
     // Onboarding

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/map/MapViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/map/MapViewModel.kt
@@ -32,6 +32,8 @@ import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import org.noiseplanet.noisecapture.services.location.UserLocationService
 import org.noiseplanet.noisecapture.services.measurement.MeasurementService
+import org.noiseplanet.noisecapture.services.settings.SettingsKey
+import org.noiseplanet.noisecapture.services.settings.UserSettingsService
 import org.noiseplanet.noisecapture.ui.components.button.IconNCButtonViewModel
 import org.noiseplanet.noisecapture.ui.components.button.NCButtonColors
 import org.noiseplanet.noisecapture.ui.components.button.NCButtonViewModel
@@ -157,6 +159,7 @@ class MapViewModel(
 
     private val locationService: UserLocationService by inject()
     private val measurementService: MeasurementService by inject()
+    private val settingsService: UserSettingsService by inject()
 
     val backgroundTilesProvider = RemoteTileStreamProvider(
         tileServerUrl = BACKGROUND_TILESET_URL
@@ -280,6 +283,14 @@ class MapViewModel(
         mapState.setStateChangeListener {
             // Whenever map orientation changes, emit new value through flow to update UI.
             _mapOrientationFlow.tryEmit(this.rotation)
+        }
+
+        settingsService.get(SettingsKey.MapLastKnownLocation)?.let { locationRecord ->
+            val (x, y) = GeoUtil.lonLatToNormalizedWebMercator(
+                latitude = locationRecord.lat,
+                longitude = locationRecord.lon,
+            )
+            viewModelScope.launch { mapState.scrollTo(x, y) }
         }
 
         if (parameters.followUserLocation) {


### PR DESCRIPTION
# Description

Store last known user location and use it as map default centroid

## Changes

- Adds a `MapLastKnownLocation` property in user defaults
- If available, use this property as map default centroid. Otherwise, fallback to Nantes city center.

## Linked issues

- #160 

## Remaining TODOs

N/A

## Checklist

- [x] Code compiles correctly on all platforms
- [x] All pre-existing tests are passing
- [ ] If needed, new tests have been added
- [ ] Extended the README / documentation if necessary
- [x] Added code has been documented
- [x] Added this change to [CHANGELOG.md](../../CHANGELOG.md) 
