### PR TITLE
Fix/details pop backstack issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Use last known user location as map default centroid (#300)
 - Updated dependencies to latest stable versions (#302)
 
+### Fixed
+
+- Deleting a measurement sometimes wouldn't exit the details screen (#303)
+
 ## [0.9.0] - 2026-05-13
 
 ### Added

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/storage/kstore/KStoreStorageService.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/storage/kstore/KStoreStorageService.kt
@@ -6,7 +6,6 @@ import io.github.xxfast.kstore.extensions.minus
 import io.github.xxfast.kstore.extensions.plus
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onCompletion
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
 import org.koin.core.component.KoinComponent
@@ -54,7 +53,7 @@ open class KStoreStorageService<RecordType : @Serializable Any>(
     /**
      * Cache references to stores that are currently subscribed to.
      */
-    private var storeCache: MutableMap<String, KStore<RecordType>> = mutableMapOf()
+    private val storeCache: MutableMap<String, KStore<RecordType>> = mutableMapOf()
 
 
     // - StorageService
@@ -114,10 +113,7 @@ open class KStoreStorageService<RecordType : @Serializable Any>(
         val store = storeCache.getOrPut(uuid) {
             getStoreForRecord(uuid)
         }
-        return store.updates.onCompletion {
-            // When unsubscribing, drop the cached reference.
-            storeCache.remove(uuid)
-        }
+        return store.updates
     }
 
     override suspend fun set(uuid: String, newValue: RecordType) {
@@ -140,6 +136,7 @@ open class KStoreStorageService<RecordType : @Serializable Any>(
         // Delete record
         val store = storeCache[uuid] ?: getStoreForRecord(uuid)
         store.delete()
+        storeCache.remove(uuid)
     }
 
     override suspend fun download(uuid: String) {


### PR DESCRIPTION
# Description

Fixes a bug that caused the measurement details page not exiting when deleting a measurement in certain circumstances

## Changes

The bug was due to the measurement store reference being dropped before the callback could be triggered due to flow unsubscribing. Instead, only drop the cache store reference when deleting the entity. 

## Linked issues

- #297 

## Remaining TODOs

N/A

## Checklist

- [x] Code compiles correctly on all platforms
- [x] All pre-existing tests are passing
- [ ] If needed, new tests have been added
- [ ] Extended the README / documentation if necessary
- [x] Added code has been documented
- [x] Added this change to [CHANGELOG.md](../../CHANGELOG.md) 
