### PR TITLE
Fix/real time average laeq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Use last known user location as map default centroid (#300)
 - Updated dependencies to latest stable versions (#302)
 
+### Fixed
+
+- Fixed incorrect measurement average level due to rounding error (#304)
+
 ## [0.9.0] - 2026-05-13
 
 ### Added

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/measurement/DefaultMeasurementService.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/measurement/DefaultMeasurementService.kt
@@ -422,7 +422,7 @@ class DefaultMeasurementService : MeasurementService, KoinComponent {
             locationSequenceIds = ongoingMeasurement.locationSequenceIds,
             leqsSequenceIds = ongoingMeasurement.leqsSequenceIds,
             recordedAudioUrl = ongoingMeasurement.recordedAudioUrl,
-            laeqMetrics = leqMetrics,
+            laeqMetrics = leqMetrics.copy(average = leqMetrics.average.roundTo(1)),
             calibrationProfile = microphoneProvider.currentCalibrationProfile.value,
         )
         measurementStorageService.set(measurement.uuid, measurement)

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/measurement/DefaultMeasurementService.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/services/measurement/DefaultMeasurementService.kt
@@ -192,7 +192,7 @@ class DefaultMeasurementService : MeasurementService, KoinComponent {
 
                 LAeqMetrics(
                     min = min(record.laeq, currentMetrics.min),
-                    average = average.roundTo(1),
+                    average = average,
                     max = max(record.laeq, currentMetrics.max),
                     recordsCount = currentMetrics.recordsCount + 1
                 )

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/spl/SoundLevelMeterViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/components/spl/SoundLevelMeterViewModel.kt
@@ -70,6 +70,7 @@ class SoundLevelMeterViewModel(
 
     val laeqMetricsFlow: StateFlow<LAeqMetrics?> = measurementService
         .getOngoingMeasurementLaeqMetricsFlow()
+        .map { it?.copy(average = it.average.roundTo(1)) }
         .stateInWhileSubscribed(
             scope = viewModelScope,
             initialValue = null,


### PR DESCRIPTION
# Description

Fixes a bug in the calculation of measurement average level on the fly while recording

## Changes

I noticed that for longer measurement the average value calculated on the fly was different from the value obtained while calculating average level on all the laeqs after stopping the recording. This was due to the average value being rounded to the nearest 0.1dBA on every new incoming sample, causing an error accumulation over time.

## Linked issues

- #291 

## Remaining TODOs

N/A

## Checklist

- [x] Code compiles correctly on all platforms
- [x] All pre-existing tests are passing
- [ ] If needed, new tests have been added
- [ ] Extended the README / documentation if necessary
- [x] Added code has been documented
- [x] Added this change to [CHANGELOG.md](../../CHANGELOG.md) 
