### PR TITLE
Force status bar color to be light with dark icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Android: Status bar icons showing white on white for some devices (#309)
+
 ## [0.9.1] - 2026-06-17
 
 ### Added

--- a/androidApp/src/main/kotlin/org/noiseplanet/noisecapture/MainActivity.kt
+++ b/androidApp/src/main/kotlin/org/noiseplanet/noisecapture/MainActivity.kt
@@ -14,7 +14,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfoV2
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.window.core.layout.WindowSizeClass
 import kotlinx.coroutines.CoroutineScope
@@ -27,8 +26,8 @@ import org.noiseplanet.noisecapture.log.Logger
 import org.noiseplanet.noisecapture.permission.delegate.PermissionDelegate
 import org.noiseplanet.noisecapture.permission.toPermission
 import org.noiseplanet.noisecapture.services.permission.PermissionService
-import org.noiseplanet.noisecapture.ui.theme.OnSurface
-import org.noiseplanet.noisecapture.ui.theme.Surface
+import org.noiseplanet.noisecapture.ui.theme.OnSurfaceLight
+import org.noiseplanet.noisecapture.ui.theme.SurfaceLight
 import org.noiseplanet.noisecapture.util.AndroidNotificationProvider
 import org.noiseplanet.noisecapture.util.NotificationProvider
 
@@ -56,8 +55,8 @@ class MainActivity : ComponentActivity() {
 
         enableEdgeToEdge(
             statusBarStyle = SystemBarStyle.light(
-                scrim = Color.Surface.toArgb(),
-                darkScrim = Color.OnSurface.toArgb(),
+                scrim = SurfaceLight.toArgb(),
+                darkScrim = OnSurfaceLight.toArgb(),
             )
         )
 

--- a/androidApp/src/main/kotlin/org/noiseplanet/noisecapture/MainActivity.kt
+++ b/androidApp/src/main/kotlin/org/noiseplanet/noisecapture/MainActivity.kt
@@ -8,11 +8,14 @@ import android.content.Intent
 import android.content.pm.ActivityInfo
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfoV2
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.window.core.layout.WindowSizeClass
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -24,6 +27,8 @@ import org.noiseplanet.noisecapture.log.Logger
 import org.noiseplanet.noisecapture.permission.delegate.PermissionDelegate
 import org.noiseplanet.noisecapture.permission.toPermission
 import org.noiseplanet.noisecapture.services.permission.PermissionService
+import org.noiseplanet.noisecapture.ui.theme.OnSurface
+import org.noiseplanet.noisecapture.ui.theme.Surface
 import org.noiseplanet.noisecapture.util.AndroidNotificationProvider
 import org.noiseplanet.noisecapture.util.NotificationProvider
 
@@ -49,7 +54,12 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        enableEdgeToEdge()
+        enableEdgeToEdge(
+            statusBarStyle = SystemBarStyle.light(
+                scrim = Color.Surface.toArgb(),
+                darkScrim = Color.OnSurface.toArgb(),
+            )
+        )
 
         initKoin(
             additionalModules = listOf(


### PR DESCRIPTION
# Description

On some devices the icons didn't adapt to the status bar color by default

## Changes

Provide explicit light and dark colors to `enableEdgeToEdge` so that the icons will be dark by default, or the status bar will become dark to adapt for light icons on devices where icons color is not dynamic.

## Linked issues

- #307 

## Remaining TODOs

N/A

## Checklist

- [x] Code compiles correctly on all platforms
- [x] All pre-existing tests are passing
- [ ] If needed, new tests have been added
- [ ] Extended the README / documentation if necessary
- [ ] Added code has been documented
- [x] Added this change to [CHANGELOG.md](../../CHANGELOG.md) 
