### PR TITLE
[WasmJS] Fix crash due to changes in Promise interop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- WasmJS: Fixed crash due to updates in Promise interop with Kotlin (#310)
+
 ## [0.9.1] - 2026-06-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-- WasmJS: Fixed crash due to updates in Promise interop with Kotlin (#310)
+- WasmJS: Fixed crash due to updates in Promise interop with Kotlin (#311)
 
 ## [0.9.1] - 2026-06-17
 

--- a/composeApp/src/wasmJsMain/kotlin/org/noiseplanet/noisecapture/audio/JsAudioSource.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/noiseplanet/noisecapture/audio/JsAudioSource.kt
@@ -80,49 +80,46 @@ internal class JsAudioSource : AudioSource(), KoinComponent {
             audioConstraints.deviceId = it.id.toJsString()
         }
 
-        window.navigator.mediaDevices.getUserMedia(
+        val mediaStream = window.navigator.mediaDevices.getUserMedia(
             MediaStreamConstraints(audio = audioConstraints)
-        ).then(onFulfilled = { mediaStream ->
-            audioContext = AudioContext()
+        ).await()
 
-            micNode = audioContext?.createMediaStreamSource(mediaStream)
-            checkNotNull(micNode) { "Failed initializing mic node" }
+        audioContext = AudioContext()
 
-            scriptProcessorNode = audioContext?.createScriptProcessor(
-                bufferSize = SAMPLES_BUFFER_SIZE,
-                numberOfInputChannels = 1,
-                numberOfOutputChannels = 1
-            )
-            checkNotNull(scriptProcessorNode) { "Failed initializing script processor node" }
+        micNode = audioContext?.createMediaStreamSource(mediaStream)
+        checkNotNull(micNode) { "Failed initializing mic node" }
 
-            scriptProcessorNode?.onaudioprocess = { audioProcessingEvent ->
-                scope.launch {
-                    val timestamp = Clock.System.now().toEpochMilliseconds()
-                    val buffer = audioProcessingEvent.inputBuffer
-                    val jsBuffer = buffer.getChannelData(0)
+        scriptProcessorNode = audioContext?.createScriptProcessor(
+            bufferSize = SAMPLES_BUFFER_SIZE,
+            numberOfInputChannels = 1,
+            numberOfOutputChannels = 1
+        )
+        checkNotNull(scriptProcessorNode) { "Failed initializing script processor node" }
 
-                    // In case of inconsistency between js buffer size and internal buffer, reallocate
-                    if (jsBuffer.length != samplesBuffer.size) {
-                        samplesBuffer = FloatArray(jsBuffer.length)
-                    }
-                    // Pour audio samples in reusable buffer
-                    for (index in 0 until samplesBuffer.size) {
-                        samplesBuffer[index] = jsBuffer[index]
-                    }
+        scriptProcessorNode?.onaudioprocess = { audioProcessingEvent ->
+            scope.launch {
+                val timestamp = Clock.System.now().toEpochMilliseconds()
+                val buffer = audioProcessingEvent.inputBuffer
+                val jsBuffer = buffer.getChannelData(0)
 
-                    emitAudioSamples(
-                        AudioSamples(
-                            timestamp,
-                            jsBuffer.toFloatArray(),
-                            buffer.sampleRate.toInt()
-                        )
-                    )
+                // In case of inconsistency between js buffer size and internal buffer, reallocate
+                if (jsBuffer.length != samplesBuffer.size) {
+                    samplesBuffer = FloatArray(jsBuffer.length)
                 }
+                // Pour audio samples in reusable buffer
+                for (index in samplesBuffer.indices) {
+                    samplesBuffer[index] = jsBuffer[index]
+                }
+
+                emitAudioSamples(
+                    AudioSamples(
+                        timestamp,
+                        jsBuffer.toFloatArray(),
+                        buffer.sampleRate.toInt()
+                    )
+                )
             }
-            mediaStream
-        }, onRejected = { error ->
-            throw IllegalStateException(error.toString())
-        }).await<JsAny>()
+        }
     }
 
     override fun startInternal() {
@@ -141,9 +138,6 @@ internal class JsAudioSource : AudioSource(), KoinComponent {
 
     override suspend fun releaseInternal() {
         pauseInternal()
-        audioContext?.close()
-            ?.catch { error ->
-                throw IllegalStateException(error.toString())
-            }?.await<JsAny>()
+//        audioContext?.close()?.await()
     }
 }

--- a/composeApp/src/wasmJsMain/kotlin/org/noiseplanet/noisecapture/interop/Audio.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/noiseplanet/noisecapture/interop/Audio.kt
@@ -17,7 +17,7 @@ external class AudioContext {
 
     val destination: AudioDestinationNode
 
-    fun close(): Promise<*>
+    fun close(): Promise<JsAny?>
     fun createMediaStreamSource(mediaStream: MediaStream): AudioNode
     fun createScriptProcessor(
         bufferSize: Int,

--- a/composeApp/src/wasmJsMain/kotlin/org/noiseplanet/noisecapture/interop/ZipJs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/noiseplanet/noisecapture/interop/ZipJs.kt
@@ -25,7 +25,7 @@ external object ZipJs {
             options: ZipAddOptions = definedExternally,
         ): Promise<EntryMetaData>
 
-        fun close(): Promise<*>
+        fun close(): Promise<JsAny?>
     }
 
     interface Reader : JsAny

--- a/composeApp/src/wasmJsMain/kotlin/org/noiseplanet/noisecapture/permission/delegate/AudioRecordPermissionDelegate.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/noiseplanet/noisecapture/permission/delegate/AudioRecordPermissionDelegate.kt
@@ -21,16 +21,16 @@ internal class AudioRecordPermissionDelegate : DefaultPermissionDelegate(
                 video = false.toJsBoolean(),
                 audio = true.toJsBoolean()
             )
-        ).then { stream ->
+        ).then(onFulfilled = { stream ->
             // Try to create an audio stream, this will trigger the audio permissions popup
             audioContext.createMediaStreamSource(stream)
             // Close this stream as we don't need it to stay open
             audioContext.close().then { void -> void }
             stream
-        }.catch { error ->
+        }, onRejected = { error ->
             // If we can't get the audio stream, we consider it's because the user has
             // denied microphone access.
             error
-        }
+        })
     }
 }

--- a/composeApp/src/wasmJsMain/kotlin/org/noiseplanet/noisecapture/permission/delegate/PersistentLocalStoragePermissionDelegate.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/noiseplanet/noisecapture/permission/delegate/PersistentLocalStoragePermissionDelegate.kt
@@ -23,7 +23,7 @@ internal class PersistentLocalStoragePermissionDelegate : DefaultPermissionDeleg
 
     override fun providePermission() {
         scope.launch {
-            navigator?.storage?.persist()?.await<JsBoolean>()
+            navigator?.storage?.persist()?.await()
         }
     }
 }

--- a/composeApp/src/wasmJsMain/kotlin/org/noiseplanet/noisecapture/services/audio/JSAudioRecordingService.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/noiseplanet/noisecapture/services/audio/JSAudioRecordingService.kt
@@ -54,17 +54,17 @@ class JSAudioRecordingService : AudioRecordingService, KoinComponent {
 
         window.navigator.mediaDevices.getUserMedia(
             MediaStreamConstraints(audio = audioConstraints)
-        ).then { stream ->
+        ).then(onFulfilled = { stream ->
             configureMediaRecorder(stream)
             blob = null
             fileName = outputFileName
             mediaRecorder?.start()
             recordingStartListener?.onRecordingStart()
             stream
-        }.catch { error ->
+        }, onRejected = { error ->
             logger.error("getUserMedia error during AudioRecorder init: $error")
             error
-        }
+        })
     }
 
     override fun stopRecordingToFile() {

--- a/composeApp/src/wasmJsMain/kotlin/org/noiseplanet/noisecapture/services/audio/JSMicrophoneProviderService.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/noiseplanet/noisecapture/services/audio/JSMicrophoneProviderService.kt
@@ -13,9 +13,7 @@ import org.noiseplanet.noisecapture.permission.Permission
 import org.noiseplanet.noisecapture.permission.PermissionState
 import org.noiseplanet.noisecapture.services.permission.PermissionService
 import org.w3c.dom.mediacapture.AUDIOINPUT
-import org.w3c.dom.mediacapture.MediaDeviceInfo
 import org.w3c.dom.mediacapture.MediaDeviceKind
-import org.w3c.dom.mediacapture.MediaStream
 import org.w3c.dom.mediacapture.MediaStreamConstraints
 
 @OptIn(ExperimentalWasmJsInterop::class)
@@ -59,10 +57,10 @@ class JSMicrophoneProviderService : MicrophoneProviderService(), KoinComponent {
 
         window.navigator.mediaDevices
             .getUserMedia(MediaStreamConstraints(audio = true.toJsBoolean()))
-            .await<MediaStream>()
+            .await()
 
         return window.navigator.mediaDevices.enumerateDevices()
-            .await<JsArray<MediaDeviceInfo>>()
+            .await()
             .toList()
             .filter { it.kind == MediaDeviceKind.Companion.AUDIOINPUT }
             .map {
@@ -78,7 +76,7 @@ class JSMicrophoneProviderService : MicrophoneProviderService(), KoinComponent {
     override suspend fun getDefaultInput(): MicrophoneInfo? {
         val mediaStream = window.navigator.mediaDevices
             .getUserMedia(MediaStreamConstraints(audio = true.toJsBoolean()))
-            .await<MediaStream>()
+            .await()
         val audioTrack = mediaStream.getAudioTracks().toList().firstOrNull() ?: return null
 
         return availableInputs.value.firstOrNull {

--- a/composeApp/src/wasmJsMain/kotlin/org/noiseplanet/noisecapture/services/storage/OPFSFileSystemService.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/noiseplanet/noisecapture/services/storage/OPFSFileSystemService.kt
@@ -35,7 +35,7 @@ class OPFSFileSystemService : FileSystemService {
 
     override suspend fun delete(fileUri: String) {
         val (fileHandle, directoryHandle) = OPFSHelper.getFileHandle(fileUri) ?: return
-        directoryHandle.removeEntry(fileHandle.name).await<Unit>()
+        directoryHandle.removeEntry(fileHandle.name).await()
     }
 
     /**
@@ -62,14 +62,14 @@ class OPFSFileSystemService : FileSystemService {
         // Add each file to the zip archive
         fileUris.forEach { fileUri ->
             val (fileHandle, _) = OPFSHelper.getFileHandle(fileUri) ?: return
-            val file = fileHandle.getFile().await<File>()
+            val file = fileHandle.getFile().await()
             val reader = ZipJs.BlobReader(file)
-            zipWriter.add(fileUri, reader).await<JsAny>()
+            zipWriter.add(fileUri, reader).await()
         }
-        zipWriter.close().await<JsAny>()
+        zipWriter.close().await()
 
         // Get zipped data as blob
-        val blob = writer.getData().await<Blob>()
+        val blob = writer.getData().await()
 
         // Download zip file
         downloadBlob(blob, "$archiveName.zip")
@@ -86,9 +86,9 @@ class OPFSFileSystemService : FileSystemService {
         val (fileHandle, _) = OPFSHelper.getFileHandle(key, createIfNotFound = true) ?: return
         val stream: FileSystemWritableFileStream = fileHandle.createWritable().await()
         // Store raw data
-        stream.write(blob).await<Unit>()
+        stream.write(blob).await()
         // Close stream
-        stream.close().await<Unit>()
+        stream.close().await()
     }
 
 

--- a/composeApp/src/wasmJsMain/kotlin/org/noiseplanet/noisecapture/util/OPFSHelper.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/noiseplanet/noisecapture/util/OPFSHelper.kt
@@ -2,6 +2,7 @@ package org.noiseplanet.noisecapture.util
 
 import io.ktor.util.toJsArray
 import kotlinx.coroutines.await
+import kotlinx.coroutines.suspendCancellableCoroutine
 import org.khronos.webgl.ArrayBuffer
 import org.khronos.webgl.Uint8Array
 import org.khronos.webgl.get
@@ -12,10 +13,8 @@ import org.noiseplanet.noisecapture.interop.storage.FileSystemFileHandle
 import org.noiseplanet.noisecapture.interop.storage.FileSystemWritableFileStream
 import org.noiseplanet.noisecapture.interop.storage.fileSystemHandleOptions
 import org.noiseplanet.noisecapture.log.Logger
-import org.w3c.files.File
 import org.w3c.files.FileReader
 import kotlin.coroutines.resume
-import kotlin.coroutines.suspendCoroutine
 
 
 /**
@@ -48,10 +47,11 @@ object OPFSHelper : KoinComponent {
         // }.await<JsBoolean>()
 
         // Get root directory handle
-        return storage.getDirectory()
-            .catch {
-                throw OPFSUnavailableException("Cannot get root directory handle")
-            }.await()
+        return try {
+            storage.getDirectory().await()
+        } catch (error: JsException) {
+            throw OPFSUnavailableException("Cannot get root directory handle", error)
+        }
     }
 
     /**
@@ -73,41 +73,41 @@ object OPFSHelper : KoinComponent {
         val dirNames = pathComponents.dropLast(1)
         val fileName = pathComponents.last()
 
-        return try {
-            // Get OPFS root directory
-            val opfsRoot = getOpfsRoot() ?: return null
+        // Get OPFS root directory
+        val opfsRoot = getOpfsRoot() ?: return null
 
-            // Set current directory to OPFS root
-            var currentDirectory = opfsRoot
+        // Set current directory to OPFS root
+        var currentDirectory = opfsRoot
 
-            // Create intermediary directories if they don't exist
-            dirNames.forEach { dirName ->
-                // Every time we create a new directory, update current directory handle
-                currentDirectory = currentDirectory.getDirectoryHandle(
-                    dirName.toJsString(),
-                    options = fileSystemHandleOptions(create = createIfNotFound)
-                ).catch {
-                    throw FileNotFoundException(dirName)
-                }.await()
-            }
-            // Get file handle, create it if necessary
-            val fileHandle: FileSystemFileHandle = currentDirectory.getFileHandle(
-                name = fileName.toJsString(),
-                options = fileSystemHandleOptions(create = createIfNotFound)
-            ).catch {
-                throw FileNotFoundException(filePath)
-            }.await()
-
-            // Return directory and file handles
-            Pair(fileHandle, currentDirectory)
-
-        } catch (error: FileNotFoundException) {
-            logger.warning(message = "Could not access file or directory", throwable = error)
-            null
-        } catch (error: OPFSUnavailableException) {
-            logger.error(message = "An error occurred while access file storage", throwable = error)
-            null
+        // Create intermediary directories if they don't exist
+        for (dirName in dirNames) {
+            // Every time we create a new directory, update current directory handle
+            currentDirectory = currentDirectory.getDirectoryHandle(
+                dirName.toJsString(),
+                options = fileSystemHandleOptions(create = true)
+            ).catch { error ->
+                logger.warning(
+                    "Couldn't get directory handle for dir $dirName",
+                    error.toThrowableOrNull()
+                )
+                null
+            }.await() ?: return null
         }
+
+        // Get file handle, create it if necessary
+        val fileHandle: FileSystemFileHandle = currentDirectory.getFileHandle(
+            name = fileName.toJsString(),
+            options = fileSystemHandleOptions(create = createIfNotFound)
+        ).catch { error ->
+            logger.warning(
+                "Couldn't get file handle for file $filePath",
+                error.toThrowableOrNull()
+            )
+            null
+        }.await() ?: return null
+
+        // Return directory and file handles
+        return Pair(fileHandle, currentDirectory)
     }
 
     /**
@@ -118,14 +118,15 @@ object OPFSHelper : KoinComponent {
      */
     suspend fun read(filePath: String): ByteArray? {
         // Get file and directory handles
+        logger.debug("READ $filePath")
         val (fileHandle, _) = getFileHandle(filePath) ?: return null
-        val file = fileHandle.getFile().await<File>()
+        val file = fileHandle.getFile().await()
 
         // Create file reader
         val reader = FileReader()
         // Read contents from file. Since FileReader relies on a callback to get the contents
         // after reading, we wrap this in a suspendCoroutine to synchronise the result
-        return suspendCoroutine { continuation ->
+        return suspendCancellableCoroutine { continuation ->
             reader.readAsArrayBuffer(file)
             reader.addEventListener("load") {
                 // Continue execution when contents are available.
@@ -152,8 +153,8 @@ object OPFSHelper : KoinComponent {
         // Get writer handle
         val stream: FileSystemWritableFileStream = fileHandle.createWritable().await()
         // Write data to file
-        stream.write(data.toJsArray()).await<Unit>()
+        stream.write(data.toJsArray()).await()
         // Close writer handle
-        stream.close().await<Unit>()
+        stream.close().await()
     }
 }


### PR DESCRIPTION
# Description

After updating dependencies for the 0.9.1 release, the wasm js deployment failed (although build does succeed) because of changes in Promise interop with Kotlin 2.4.0

## Changes

- Fixed usages of `.catch { error -> }` for error handling
- Fixed typing of `.await<T>()` that needs to inherit JSAny in all cases

## Linked issues

- #308 

## Remaining TODOs

N/A

## Checklist

- [x] Code compiles correctly on all platforms
- [x] All pre-existing tests are passing
- [ ] If needed, new tests have been added
- [ ] Extended the README / documentation if necessary
- [x] Added code has been documented
- [x] Added this change to [CHANGELOG.md](../../CHANGELOG.md) 
