### PR TITLE
Fix/export delete menus options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Android: Status bar icons showing white on white for some devices (#309)
 - WasmJS: Fixed crash due to updates in Promise interop with Kotlin (#311)
+- Export and delete menus from measurement details were unresponsive (#315)
 
 ## [0.9.1] - 2026-06-17
 

--- a/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/details/manage/ManageMeasurementView.kt
+++ b/composeApp/src/commonMain/kotlin/org/noiseplanet/noisecapture/ui/features/details/manage/ManageMeasurementView.kt
@@ -142,7 +142,7 @@ fun ManageMeasurementView(
                                     label = stringResource(item.label),
                                     supportingText = item.supportingText?.let { stringResource(it) },
                                     onClick = {
-                                        item.onClick
+                                        item.onClick()
                                         showExportMenu = false
                                     },
                                 )
@@ -171,7 +171,7 @@ fun ManageMeasurementView(
                                     label = stringResource(item.label),
                                     supportingText = item.supportingText?.let { stringResource(it) },
                                     onClick = {
-                                        item.onClick
+                                        item.onClick()
                                         showDeleteMenu = false
                                     },
                                 )


### PR DESCRIPTION
# Description

Fixes a bug where export and delete menu options didn't trigger their associated callbacks

## Changes

Callbacks weren't called but just accessed (missing parenthesis)

## Linked issues

- Closes #314 

## Remaining TODOs

N/A

## Checklist

- [x] Code compiles correctly on all platforms
- [x] All pre-existing tests are passing
- [ ] If needed, new tests have been added
- [ ] Extended the README / documentation if necessary
- [x] Added code has been documented
- [x] Added this change to [CHANGELOG.md](../../CHANGELOG.md) 
